### PR TITLE
Add Bedrock role name to the validation allow list

### DIFF
--- a/aws-doc-sdk-examples-tools/validator_config.py
+++ b/aws-doc-sdk-examples-tools/validator_config.py
@@ -169,6 +169,7 @@ ALLOW_LIST = {
     "nFindProductsWithNegativePriceWithConfig",
     "preview/examples/cognitoidentityprovider",
     "preview/examples/lambda/src/bin/scenario",
+    "role/AmazonBedrockExecutionRoleForAgents",
     "role/AmazonSageMakerGeospatialFullAccess",
     "s3_client_side_encryption_sym_master_key",
     "serial/CORE_THING_NAME/write/dev/serial1",


### PR DESCRIPTION
This PR adds a Bedrock role name to the validators' allow list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
