### PR TITLE
Require that single-action examples are not duplicated and specify exactly one service and one action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__
 .pytest_cache
 .DS_Store
 *.egg-info
+.idea/
 build/
 dist/

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -188,7 +188,7 @@ class DocGen:
         check_files(self.root, check_spdx, self.validation, self.errors)
         verify_sample_files(self.root, self.validation, self.errors)
         validate_metadata(self.root, self.errors)
-        validate_no_duplicate_api_examples([*self.examples.values()], self.errors)
+        validate_no_duplicate_api_examples(*self.examples.values(), self.errors)
         validate_snippets(
             [*self.examples.values()],
             self.snippets,

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterable, List, Optional, Set
 
 # from os import glob
 
-from .metadata import Example, parse as parse_examples
+from .metadata import Example, parse as parse_examples, validate_no_duplicate_api_examples
 from .metadata_errors import MetadataErrors, MetadataError
 from .metadata_validator import validate_metadata
 from .project_validator import check_files, verify_sample_files, ValidationConfig
@@ -184,6 +184,7 @@ class DocGen:
         check_files(self.root, check_spdx, self.validation, self.errors)
         verify_sample_files(self.root, self.validation, self.errors)
         validate_metadata(self.root, self.errors)
+        validate_no_duplicate_api_examples([*self.examples.values()], self.errors)
         validate_snippets(
             [*self.examples.values()],
             self.snippets,

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -9,7 +9,11 @@ from typing import Dict, Iterable, List, Optional, Set
 
 # from os import glob
 
-from .metadata import Example, parse as parse_examples, validate_no_duplicate_api_examples
+from .metadata import (
+    Example,
+    parse as parse_examples,
+    validate_no_duplicate_api_examples,
+)
 from .metadata_errors import MetadataErrors, MetadataError
 from .metadata_validator import validate_metadata
 from .project_validator import check_files, verify_sample_files, ValidationConfig

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -188,7 +188,7 @@ class DocGen:
         check_files(self.root, check_spdx, self.validation, self.errors)
         verify_sample_files(self.root, self.validation, self.errors)
         validate_metadata(self.root, self.errors)
-        validate_no_duplicate_api_examples(*self.examples.values(), self.errors)
+        validate_no_duplicate_api_examples(self.examples.values(), self.errors)
         validate_snippets(
             [*self.examples.values()],
             self.snippets,

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -406,7 +406,9 @@ def parse(
     return examples, errors
 
 
-def validate_no_duplicate_api_examples(examples: Iterable[Example], errors: MetadataErrors):
+def validate_no_duplicate_api_examples(
+    examples: Iterable[Example], errors: MetadataErrors
+):
     """Call this on a full set of examples to verify that there are no duplicate API examples."""
     svc_action_map = defaultdict(set)
     for example in [ex for ex in examples if ex.category == "Api"]:

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Union
 from os.path import splitext
@@ -278,6 +279,14 @@ class Example:
             category = "Api" if len(parsed_services) == 1 else "Cross"
         is_action = category == "Api"
 
+        if is_action:
+            svc_actions = []
+            for svc, actions in parsed_services.items():
+                for action in actions:
+                    svc_actions.append(f"{svc}:{action}")
+            if len(svc_actions) != 1:
+                errors.append(metadata_errors.APIMustHaveOneServiceOneAction(svc_actions=", ".join(svc_actions)))
+
         service_main = yaml.get("service_main", None)
         if service_main is not None and service_main not in services:
             try:
@@ -391,6 +400,21 @@ def parse(
         examples.append(example)
 
     return examples, errors
+
+
+def validate_no_duplicate_api_examples(examples: List[Example], errors: MetadataErrors):
+    """Call this on a full set of examples to verify that there are no duplicate API examples."""
+    svc_action_map = defaultdict(list)
+    for example in [ex for ex in examples if ex.category == "Api"]:
+        for service, actions in example.services.items():
+            for action in actions:
+                svc_action_map[f"{service}:{action}"].append(example)
+    for svc_action, ex_items in svc_action_map.items():
+        if len(ex_items) > 1:
+            errors.append(metadata_errors.DuplicateAPIExample(
+                id=", ".join({ex_item.id for ex_item in ex_items}),
+                file=", ".join({ex_item.file for ex_item in ex_items}),
+                svc_action=svc_action))
 
 
 def main():

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union, Iterable
 from os.path import splitext
 
 from aws_doc_sdk_examples_tools import metadata_errors
@@ -406,13 +406,13 @@ def parse(
     return examples, errors
 
 
-def validate_no_duplicate_api_examples(examples: List[Example], errors: MetadataErrors):
+def validate_no_duplicate_api_examples(examples: Iterable[Example], errors: MetadataErrors):
     """Call this on a full set of examples to verify that there are no duplicate API examples."""
-    svc_action_map = defaultdict(list)
+    svc_action_map = defaultdict(set)
     for example in [ex for ex in examples if ex.category == "Api"]:
         for service, actions in example.services.items():
             for action in actions:
-                svc_action_map[f"{service}:{action}"].append(example)
+                svc_action_map[f"{service}:{action}"].add(example)
     for svc_action, ex_items in svc_action_map.items():
         if len(ex_items) > 1:
             errors.append(

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -285,7 +285,11 @@ class Example:
                 for action in actions:
                     svc_actions.append(f"{svc}:{action}")
             if len(svc_actions) != 1:
-                errors.append(metadata_errors.APIMustHaveOneServiceOneAction(svc_actions=", ".join(svc_actions)))
+                errors.append(
+                    metadata_errors.APIMustHaveOneServiceOneAction(
+                        svc_actions=", ".join(svc_actions)
+                    )
+                )
 
         service_main = yaml.get("service_main", None)
         if service_main is not None and service_main not in services:
@@ -411,10 +415,13 @@ def validate_no_duplicate_api_examples(examples: List[Example], errors: Metadata
                 svc_action_map[f"{service}:{action}"].append(example)
     for svc_action, ex_items in svc_action_map.items():
         if len(ex_items) > 1:
-            errors.append(metadata_errors.DuplicateAPIExample(
-                id=", ".join({ex_item.id for ex_item in ex_items}),
-                file=", ".join({ex_item.file for ex_item in ex_items}),
-                svc_action=svc_action))
+            errors.append(
+                metadata_errors.DuplicateAPIExample(
+                    id=", ".join({ex_item.id for ex_item in ex_items}),
+                    file=", ".join({ex_item.file for ex_item in ex_items}),
+                    svc_action=svc_action,
+                )
+            )
 
 
 def main():

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os.path
 import re
 from dataclasses import dataclass
 from typing import Optional, Iterator, Iterable, List, TypeVar
@@ -22,7 +23,6 @@ class MetadataError:
 
     def __str__(self):
         return f"{self.prefix()} {self.message()}"
-
 
 @dataclass
 class MetadataParseError(MetadataError):
@@ -234,6 +234,17 @@ class APIExampleCannotAddService(SdkVersionError):
 
 
 @dataclass
+class APIMustHaveOneServiceOneAction(MetadataParseError):
+    svc_actions: str = ""
+
+    def message(self):
+        return (
+            f"is an API example but lists svc:actions as '{self.svc_actions}'. "
+            f"API examples must contain exactly one service and one action."
+        )
+
+
+@dataclass
 class MissingSnippetTag(SdkVersionError):
     tag: str = ""
 
@@ -256,13 +267,20 @@ class DuplicateService(MetadataParseError):
     def message(self):
         return f"service {self.services} listed more than once"
 
-
 @dataclass
 class DuplicateExample(MetadataParseError):
     other_file: str = ""
 
     def message(self):
         return f"also found in {self.other_file}"
+
+
+@dataclass
+class DuplicateAPIExample(MetadataError):
+    svc_action: str = ""
+
+    def message(self):
+        return f"multiple API examples found for service:action {self.svc_action}"
 
 
 @dataclass

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -24,6 +24,7 @@ class MetadataError:
     def __str__(self):
         return f"{self.prefix()} {self.message()}"
 
+
 @dataclass
 class MetadataParseError(MetadataError):
     id: Optional[str] = None
@@ -266,6 +267,7 @@ class DuplicateService(MetadataParseError):
 
     def message(self):
         return f"service {self.services} listed more than once"
+
 
 @dataclass
 class DuplicateExample(MetadataParseError):

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -163,6 +163,7 @@ CROSS_META = """
 cross_DeleteTopic:
   title: Delete Topic
   title_abbrev: delete topic
+  category: Cross-service examples
   languages:
      Java:
        versions:
@@ -187,7 +188,7 @@ def test_parse_cross():
     example = Example(
         file="cross.yaml",
         id="cross_DeleteTopic",
-        category="Api",
+        category="Cross-service examples",
         title="Delete Topic",
         title_abbrev="delete topic",
         synopsis="",
@@ -203,6 +204,7 @@ autogluon_tabular_with_sagemaker_pipelines:
   title_abbrev: AutoGluon Tabular with SageMaker Pipelines
   synopsis: use AutoGluon with SageMaker Pipelines.
   source_key: amazon-sagemaker-examples
+  category: Curated examples
   languages:
      Java:
        versions:
@@ -225,7 +227,7 @@ def test_parse_curated():
     example = Example(
         id="autogluon_tabular_with_sagemaker_pipelines",
         file="curated.yaml",
-        category="Api",
+        category="Curated examples",
         title="AutoGluon Tabular with SageMaker Pipelines",
         title_abbrev="AutoGluon Tabular with SageMaker Pipelines",
         source_key="amazon-sagemaker-examples",
@@ -349,6 +351,11 @@ def test_verify_load_successful():
         (
             "errors_metadata.yaml",
             [
+                metadata_errors.APIMustHaveOneServiceOneAction(
+                    file="errors_metadata.yaml",
+                    id="sqs_WrongServiceSlug",
+                    svc_actions="",
+                ),
                 metadata_errors.UnknownLanguage(
                     language="Perl",
                     file="errors_metadata.yaml",
@@ -408,11 +415,6 @@ def test_verify_load_successful():
                     id="cross_TestExample_Versions",
                     language="Java",
                     sdk_version=None,
-                ),
-                metadata_errors.APIExampleCannotAddService(
-                    language="Java",
-                    file="errors_metadata.yaml",
-                    id="cross_TestExample_Versions",
                 ),
                 metadata_errors.MissingCrossContent(
                     file="errors_metadata.yaml",

--- a/aws_doc_sdk_examples_tools/spdx_test.py
+++ b/aws_doc_sdk_examples_tools/spdx_test.py
@@ -46,7 +46,7 @@ from .spdx import verify_spdx, MissingSPDX
         (
             "py",
             ("def foo():\n\tpass"),
-            [MissingSPDX(file="/tmp/file.py")],
+            [MissingSPDX(file=str(Path("/tmp/file.py")))],
         ),
     ],
 )

--- a/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
@@ -35,7 +35,7 @@ sns_TestExample:
         - sdk_version: 2
           sdkguide: http://sdk/guide/url
   services:
-    sns:
+    sns: {TestAction}
 sns_TestExample2:
   title: Test title
   title_abbrev: Test title abbrev
@@ -50,13 +50,14 @@ sns_TestExample2:
             - snippet_tags:
                 - this.snippet.does.not.exist
   services:
-    garbled:
-    sns:
+    garbled: {TestAction}
+    sns: {TestAction}
 cross_TestExample_Versions:
   title: Test title
   title_abbrev: Test title abbrev
   synopsis: |-
     This synopsis is okay.
+  category: Cross-service examples
   languages:
     Java:
       versions:
@@ -82,6 +83,7 @@ cross_TestExample_Missing:
           block_content: missing_block_content.xml
   services:
     sns:
+    sqs:
 snsBadFormat:
   title: Test title
   title_abbrev: Test title abbrev
@@ -93,4 +95,4 @@ snsBadFormat:
         - sdk_version: 2
           github: github/link
   services:
-    sns:
+    sns: {TestAction}

--- a/aws_doc_sdk_examples_tools/test_resources/formaterror_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/formaterror_metadata.yaml
@@ -9,7 +9,7 @@ WrongNameFormat:
           block_content: test/block
           github: javav2/example_code/sns
   services:
-    sns:
+    sns: {TestAction}
 cross_TestExample:
   title: Test title
   title_abbrev: Test title abbrev
@@ -22,4 +22,5 @@ cross_TestExample:
           add_services:
             garbage:
   services:
-    sns:
+    sns: {TestAction}
+    sqs: {TestAction}


### PR DESCRIPTION
This is the first part of validation needed for canonical title update:

- Validate that API examples have exactly one service and one action.
- Check for duplicate API examples by svc:action combo.
- Update tests to pass with canonical name validation updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
