### PR TITLE
Enforce strict title format as an opt-in feature

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,5 +18,5 @@ runs:
       run: pip install -e "${{ github.action_path }}"
       shell: bash
     - name: Run validator
-      run: python3 -m "aws_doc_sdk_examples_tools.validate" --root "${{ inputs.root }}" --doc_gen_only "${{ inputs.doc_gen_only }}"
+      run: python3 -m "aws_doc_sdk_examples_tools.validate" --root "${{ inputs.root }}" --doc_gen_only "${{ inputs.doc_gen_only }}" --strict-titles "${{ inputs.strict_titles }}"
       shell: bash

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -111,9 +111,9 @@ class DocGen:
                 self.examples[id] = example
 
     @classmethod
-    def empty(cls) -> "DocGen":
+    def empty(cls, validation: ValidationConfig = ValidationConfig()) -> "DocGen":
         return DocGen(
-            root=Path("/"), errors=MetadataErrors(), validation=ValidationConfig()
+            root=Path("/"), errors=MetadataErrors(), validation=validation
         )
 
     def clone(self) -> "DocGen":
@@ -194,8 +194,9 @@ class DocGen:
         return self
 
     @classmethod
-    def from_root(cls, root: Path, config: Optional[Path] = None) -> "DocGen":
-        return DocGen.empty().for_root(root, config)
+    def from_root(cls, root: Path, config: Optional[Path] = None, validation: ValidationConfig = ValidationConfig()
+                  ) -> "DocGen":
+        return DocGen.empty(validation=validation).for_root(root, config)
 
     def validate(self):
         for sdk in self.sdks.values():

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -181,6 +181,7 @@ class DocGen:
                     self.sdks,
                     self.services,
                     self.cross_blocks,
+                    self.validation,
                 )
                 self.extend_examples(examples)
                 self.errors.extend(errs)

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -298,7 +298,7 @@ class Example:
                 if title or title_abbrev or synopsis:
                     errors.append(metadata_errors.APICannotHaveTitleFields())
             else:
-                if not title or not title_abbrev or not synopsis:
+                if not (title and title_abbrev and (synopsis or synopsis_list)):
                     errors.append(metadata_errors.NonAPIMustHaveTitleFields())
 
         service_main = yaml.get("service_main", None)
@@ -385,12 +385,14 @@ def get_with_valid_entities(
     return field
 
 
-def idFormat(id: str, services: Dict[str, Service]) -> bool:
+def check_id_format(id: str, parsed_services: Dict[str, set[str]], check_action: bool, errors: MetadataErrors):
     [service, *rest] = id.split("_")
     if len(rest) == 0:
-        return False
-    return service in services or service in ["cross", "serverless"]
-
+        errors.append(metadata_errors.NameFormat(id=id))
+    elif service not in parsed_services and service not in ["cross", "serverless"]:
+        errors.append(metadata_errors.NameFormat(id=id))
+    elif check_action and (len(rest) > 1 or rest[0] not in parsed_services.get(service, {})):
+        errors.append(metadata_errors.ActionNameFormat(id=id))
 
 def parse(
     file: str,
@@ -403,9 +405,12 @@ def parse(
     examples: List[Example] = []
     errors = MetadataErrors()
     for id in yaml:
-        if not idFormat(id, services):
-            errors.append(metadata_errors.NameFormat(file=file, id=id))
         example, example_errors = Example.from_yaml(yaml[id], sdks, services, blocks, validation)
+        check_id_format(
+            id,
+            example.services,
+            validation.strict_titles and example.category == "Api",
+            example_errors)
         for error in example_errors:
             error.file = file
             error.id = id

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -205,12 +205,12 @@ class ExampleMergeMismatchedId(MetadataError):
 class Example:
     id: str
     file: str
-    # Human readable title. TODO: Defaults to slug-to-title of the ID if not provided.
-    title: Optional[str]
-    # Used in the TOC. TODO: Defaults to slug-to-title of the ID if not provided.
-    title_abbrev: Optional[str]
-    synopsis: str
     languages: Dict[str, Language]
+    # Human readable title. TODO: Defaults to slug-to-title of the ID if not provided.
+    title: Optional[str] = field(default="")
+    # Used in the TOC. TODO: Defaults to slug-to-title of the ID if not provided.
+    title_abbrev: Optional[str] = field(default="")
+    synopsis: Optional[str] = field(default="")
     # String label categories. Categories inferred by cross-service with multiple services, and can be whatever else it wants. Controls where in the TOC it appears.
     category: Optional[str] = field(default=None)
     # Link to additional topic places.
@@ -290,6 +290,11 @@ class Example:
                         svc_actions=", ".join(svc_actions)
                     )
                 )
+            if title or title_abbrev or synopsis:
+                errors.append(metadata_errors.APICannotHaveTitleFields())
+        else:
+            if not title or not title_abbrev or not synopsis:
+                errors.append(metadata_errors.NonAPIMustHaveTitleFields())
 
         service_main = yaml.get("service_main", None)
         if service_main is not None and service_main not in services:

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -125,6 +125,12 @@ class NameFormat(MetadataParseError):
 
 
 @dataclass
+class ActionNameFormat(MetadataParseError):
+    def message(self):
+        return "name of API example does not match the required format of 'svc_Action'"
+
+
+@dataclass
 class MissingCrossContent(MetadataParseError):
     block: str = ""
 

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -244,6 +244,19 @@ class APIMustHaveOneServiceOneAction(MetadataParseError):
             f"API examples must contain exactly one service and one action."
         )
 
+@dataclass
+class APICannotHaveTitleFields(MetadataParseError):
+    def message(self):
+        return(
+            f"is an API example and defines title, title_abbrev, or synopsis. "
+            f"API examples cannot define these fields because they are generated.")
+
+@dataclass
+class NonAPIMustHaveTitleFields(MetadataParseError):
+    def message(self):
+        return(
+            f"is not an API example and does not define title, title_abbrev, or synopsis. "
+            f"Non-API examples must define these fields.")
 
 @dataclass
 class MissingSnippetTag(SdkVersionError):

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -98,10 +98,6 @@ DOC_GEN = DocGen(
 
 GOOD_SINGLE_CPP = """
 sns_DeleteTopic:
-   title: Deleting an &SNS; topic
-   title_abbrev: Deleting a topic
-   synopsis: |-
-     Shows how to delete an &SNS; topic.
    languages:
      C++:
        versions:
@@ -146,9 +142,6 @@ def test_parse():
         file="test_cpp.yaml",
         id="sns_DeleteTopic",
         category="Cross",
-        title="Deleting an &SNS; topic",
-        title_abbrev="Deleting a topic",
-        synopsis="Shows how to delete an &SNS; topic.",
         services={
             "sns": set(["Operation1", "Operation2"]),
             "ses": set(["Operation1", "Operation2"]),

--- a/aws_doc_sdk_examples_tools/project_validator.py
+++ b/aws_doc_sdk_examples_tools/project_validator.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 class ValidationConfig:
     allow_list: Set[str] = field(default_factory=set)
     sample_files: Set[str] = field(default_factory=set)
+    strict_titles: bool = False
 
     def clone(self):
         return ValidationConfig(

--- a/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
@@ -1,4 +1,4 @@
- sqs_WrongServiceSlug:
+sqs_WrongServiceSlug:
   title: Test title
   title_abbrev: Title abbrev test
   synopsis: |-

--- a/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
@@ -1,4 +1,4 @@
-sqs_WrongServiceSlug:
+ sqs_WrongServiceSlug:
   title: Test title
   title_abbrev: Title abbrev test
   synopsis: |-

--- a/aws_doc_sdk_examples_tools/test_resources/formaterror_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/formaterror_metadata.yaml
@@ -2,6 +2,7 @@ WrongNameFormat:
   title: Test title
   title_abbrev: Test title abbrev
   synopsis: Test synopsis
+  category: Test
   languages:
     Java:
       versions:

--- a/aws_doc_sdk_examples_tools/validate.py
+++ b/aws_doc_sdk_examples_tools/validate.py
@@ -28,7 +28,7 @@ def main():
         "--strict_titles",
         type=literal_eval,
         default=False,
-        help="Strict title requirements: Action examples must not have title/title_abbrev; non-Acton examples "
+        help="Strict title requirements: Action examples must not have title/title_abbrev; non-Action examples "
              "must have them.",
         required=False,
     )

--- a/aws_doc_sdk_examples_tools/validate.py
+++ b/aws_doc_sdk_examples_tools/validate.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from sys import exit
 
 from .doc_gen import DocGen
-from .project_validator import check_files, verify_sample_files
+from .project_validator import check_files, verify_sample_files, ValidationConfig
 
 
 def main():
@@ -24,10 +24,18 @@ def main():
         help="Only perform extended validation on snippet contents",
         required=False,
     )
+    parser.add_argument(
+        "--strict_titles",
+        type=literal_eval,
+        default=False,
+        help="Strict title requirements: Action examples must not have title/title_abbrev; non-Acton examples "
+             "must have them.",
+        required=False,
+    )
     args = parser.parse_args()
     root_path = Path(args.root).resolve()
 
-    doc_gen = DocGen.from_root(root=root_path)
+    doc_gen = DocGen.from_root(root=root_path, validation=ValidationConfig(strict_titles=args.strict_titles))
     doc_gen.collect_snippets(snippets_root=root_path)
     doc_gen.validate()
     if not args.doc_gen_only:


### PR DESCRIPTION
This adds the ability to make title fields conform to standards for canonical naming:

* `title`, `title_abbrev`, `synopsis`, `synopsis_list` are disallowed for Action examples.
* `title`, `title_abbrev`, and one of `synopsis` or `synopsis_list` are required for all other examples.
* The ID of Action examples must be in the form `svc_Action` where `svc` is in the `services` list and `Action` is an Action.

**Notes**

* This was added as an opt-in feature so that consumers can include these fields for their own purposes if they like, but they will be ignored by the backend, which generates titles for Action examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
