### PR TITLE
Add *.csx to validator

### DIFF
--- a/aws_doc_sdk_examples_tools/validator_config.py
+++ b/aws_doc_sdk_examples_tools/validator_config.py
@@ -13,6 +13,7 @@ EXT_LOOKUP = {
     ".cmd": "AWS-CLI",
     ".cpp": "C++",
     ".cs": "C#",
+    ".csx": "C#",
     ".css": "CSS",
     ".go": "Go",
     ".h": "C++",


### PR DESCRIPTION
This PR adds the file extension ".csx" (C#) to the validator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
