### PR TITLE
Add doc_filenames to Example

### DIFF
--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -238,7 +238,7 @@ class Example:
     service_main: Optional[str] = field(default=None)
     services: Dict[str, Set[str]] = field(default_factory=dict)
     # HTML file names corresponding to the documentation pages in the Code Library
-    doc_filenames: Optional[DocFilenames] = field(default_factory=dict)
+    doc_filenames: Optional[DocFilenames] = field(default=None)
     synopsis_list: List[str] = field(default_factory=list)
     source_key: Optional[str] = field(default=None)
 
@@ -390,7 +390,7 @@ def parse_services(
 ALLOWED = ["&AWS;", "&AWS-Region;", "&AWS-Regions;" "AWSJavaScriptSDK"]
 
 
-def get_doc_filenames(example_id: str, example: Example) -> DocFilenames:
+def get_doc_filenames(example_id: str, example: Example) -> Optional[DocFilenames]:
     # API examples
     if len(example.services) == 1:
         service_id = next(iter(example.services))
@@ -405,11 +405,12 @@ def get_doc_filenames(example_id: str, example: Example) -> DocFilenames:
     # Multi-service examples
     elif len(example.services) > 1:
         return {
+            "service_page": None,
             "sdk_pages": [
                 f"{example_id}_{language.property}_{language_ver.sdk_version}_topic"
                 for _, language in example.languages.items()
                 for language_ver in language.versions
-            ]
+            ],
         }
     else:
         return None

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-import logging
-from typing import Any, Dict, List, Optional, Set, Union, Iterable
+from typing import Any, Dict, List, Optional, Set, Union, Iterable, TypedDict
 from os.path import splitext
 from .project_validator import ValidationConfig
 
@@ -147,6 +146,7 @@ class Version:
 @dataclass
 class Language:
     name: str
+    property: str
     versions: List[Version]
 
     def merge(self, other: "Language", errors: MetadataErrors):
@@ -187,6 +187,9 @@ class Language:
         if name not in sdks:
             errors.append(metadata_errors.UnknownLanguage(language=name))
 
+        sdk = sdks.get(name)
+        property = sdk.property if sdk else ""
+
         yaml_versions: List[Dict[str, Any]] | None = yaml.get("versions")
         if yaml_versions is None or len(yaml_versions) == 0:
             errors.append(metadata_errors.MissingField(field="versions"))
@@ -204,7 +207,12 @@ class Language:
             if isinstance(error, MetadataParseError):
                 error.language = name
 
-        return cls(name, versions), errors
+        return cls(name, property, versions), errors
+
+
+class DocFilenames(TypedDict):
+    service_page: Optional[str]
+    sdk_pages: Optional[List[str]]
 
 
 @dataclass
@@ -226,6 +234,8 @@ class Example:
     # List of services used by the examples. Lines up with those in services.yaml.
     service_main: Optional[str] = field(default=None)
     services: Dict[str, Set[str]] = field(default_factory=dict)
+    # HTML file names corresponding to the documentation pages in the Code Library
+    doc_filenames: Optional[DocFilenames] = field(default_factory=dict)
     synopsis_list: List[str] = field(default_factory=list)
     source_key: Optional[str] = field(default=None)
 
@@ -377,6 +387,31 @@ def parse_services(
 ALLOWED = ["&AWS;", "&AWS-Region;", "&AWS-Regions;" "AWSJavaScriptSDK"]
 
 
+def get_doc_filenames(example_id: str, example: Example) -> DocFilenames:
+    # API examples
+    if len(example.services) == 1:
+        service_id = next(iter(example.services))
+        return {
+            "service_page": f"{service_id}_example_{example_id}_section",
+            "sdk_pages": [
+                f"{language.property}_{language_ver.sdk_version}_{service_id}_code_examples"
+                for _, language in example.languages.items()
+                for language_ver in language.versions
+            ],
+        }
+    # Multi-service examples
+    elif len(example.services) > 1:
+        return {
+            "sdk_pages": [
+                f"{example_id}_{language.property}_{language_ver.sdk_version}_topic"
+                for _, language in example.languages.items()
+                for language_ver in language.versions
+            ]
+        }
+    else:
+        return None
+
+
 def get_with_valid_entities(
     name: str, d: Dict[str, str], errors: MetadataErrors, opt: bool = False
 ) -> str:
@@ -444,6 +479,7 @@ def parse(
         errors.extend(example_errors)
         example.file = file
         example.id = id
+        example.doc_filenames = get_doc_filenames(id, example)
         examples.append(example)
 
     return examples, errors

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -212,6 +212,8 @@ class Language:
 
 
 class DocFilenames(TypedDict):
+    # Names that match Code Library entries.
+    # e.g. https://docs.aws.amazon.com/code-library/latest/ug/{service_page or sdk_pages[i]}.html
     service_page: Optional[str]
     sdk_pages: Optional[List[str]]
 

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -146,6 +146,7 @@ class Version:
 @dataclass
 class Language:
     name: str
+    # A downcased, special-character-free version of the name. Matches a key of the same name in sdks.yaml.
     property: str
     versions: List[Version]
 

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -152,7 +152,10 @@ def test_parse():
             "ses": set(["Operation1", "Operation2"]),
             "sqs": set(),
         },
-        doc_filenames={"sdk_pages": ["sns_DeleteTopic_cpp_1_topic"]},
+        doc_filenames={
+            "sdk_pages": ["sns_DeleteTopic_cpp_1_topic"],
+            "service_page": None,
+        },
         languages={"C++": language},
     )
     assert parsed[0] == example
@@ -360,6 +363,7 @@ def test_parse_cross():
             "sdk_pages": [
                 "cross_DeleteTopic_java_3_topic",
             ],
+            "service_page": None,
         },
         languages={"Java": language},
     )
@@ -506,6 +510,7 @@ def test_verify_load_successful():
                 "sns_TestExample_javascript_3_topic",
                 "sns_TestExample_php_3_topic",
             ],
+            "service_page": None,
         },
         services={"sns": set(), "sqs": set()},
     )

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -85,10 +85,10 @@ SERVICES = {
     ),
 }
 SDKS = {
-    "C++": Sdk(name="C++", versions=[], guide="", property=""),
-    "Java": Sdk(name="Java", versions=[], guide="", property=""),
-    "JavaScript": Sdk(name="JavaScript", versions=[], guide="", property=""),
-    "PHP": Sdk(name="PHP", versions=[], guide="", property=""),
+    "C++": Sdk(name="C++", versions=[], guide="", property="cpp"),
+    "Java": Sdk(name="Java", versions=[], guide="", property="java"),
+    "JavaScript": Sdk(name="JavaScript", versions=[], guide="", property="javascript"),
+    "PHP": Sdk(name="PHP", versions=[], guide="", property="php"),
 }
 DOC_GEN = DocGen(
     root=Path(),
@@ -128,6 +128,7 @@ def test_parse():
     assert len(parsed) == 1
     language = Language(
         name="C++",
+        property="cpp",
         versions=[
             Version(
                 sdk_version=1,
@@ -151,6 +152,7 @@ def test_parse():
             "ses": set(["Operation1", "Operation2"]),
             "sqs": set(),
         },
+        doc_filenames={"sdk_pages": ["sns_DeleteTopic_cpp_1_topic"]},
         languages={"C++": language},
     )
     assert parsed[0] == example
@@ -204,6 +206,7 @@ def test_parse_strict_titles():
     assert len(parsed) == 2
     language = Language(
         name="C++",
+        property="cpp",
         versions=[
             Version(
                 sdk_version=1,
@@ -225,6 +228,10 @@ def test_parse_strict_titles():
         services={
             "sns": {"GoodOne"},
         },
+        doc_filenames={
+            "sdk_pages": ["cpp_1_sns_code_examples"],
+            "service_page": "sns_example_sns_GoodOne_section",
+        },
         languages={"C++": language},
     )
     example_scenario = Example(
@@ -234,6 +241,10 @@ def test_parse_strict_titles():
         title_abbrev="Scenario title abbrev",
         synopsis="scenario synopsis.",
         category="Scenarios",
+        doc_filenames={
+            "sdk_pages": ["cpp_1_sns_code_examples"],
+            "service_page": "sns_example_sns_GoodScenario_section",
+        },
         services={
             "sns": {"GoodOne"},
         },
@@ -316,6 +327,7 @@ cross_DeleteTopic:
            block_content: cross_DeleteTopic_block.xml
   services:
      sns:
+     ses:
 """
 
 
@@ -333,6 +345,7 @@ def test_parse_cross():
     assert len(actual) == 1
     language = Language(
         name="Java",
+        property="java",
         versions=[Version(sdk_version=3, block_content="cross_DeleteTopic_block.xml")],
     )
     example = Example(
@@ -342,7 +355,12 @@ def test_parse_cross():
         title="Delete Topic",
         title_abbrev="delete topic",
         synopsis="",
-        services={"sns": set()},
+        services={"ses": set(), "sns": set()},
+        doc_filenames={
+            "sdk_pages": [
+                "cross_DeleteTopic_java_3_topic",
+            ],
+        },
         languages={"Java": language},
     )
     assert actual[0] == example
@@ -374,6 +392,7 @@ def test_parse_curated():
     assert len(actual) == 1
     language = Language(
         name="Java",
+        property="java",
         versions=[Version(sdk_version=2, block_content="block.xml")],
     )
     example = Example(
@@ -385,6 +404,12 @@ def test_parse_curated():
         source_key="amazon-sagemaker-examples",
         languages={"Java": language},
         services={"s3": set()},
+        doc_filenames={
+            "sdk_pages": [
+                "java_2_s3_code_examples",
+            ],
+            "service_page": "s3_example_s3_autogluon_tabular_with_sagemaker_pipelines_section",
+        },
         synopsis="use AutoGluon with SageMaker Pipelines.",
     )
 
@@ -397,6 +422,7 @@ def test_verify_load_successful():
     assert len(actual) == 1
     java = Language(
         name="Java",
+        property="java",
         versions=[
             Version(
                 sdk_version=2,
@@ -412,6 +438,7 @@ def test_verify_load_successful():
 
     javascript = Language(
         name="JavaScript",
+        property="javascript",
         versions=[
             Version(
                 sdk_version=3,
@@ -433,6 +460,7 @@ def test_verify_load_successful():
 
     php = Language(
         name="PHP",
+        property="php",
         versions=[
             Version(
                 sdk_version=3,
@@ -472,6 +500,13 @@ def test_verify_load_successful():
         category="Usage",
         service_main=None,
         languages=languages,
+        doc_filenames={
+            "sdk_pages": [
+                "sns_TestExample_java_2_topic",
+                "sns_TestExample_javascript_3_topic",
+                "sns_TestExample_php_3_topic",
+            ],
+        },
         services={"sns": set(), "sqs": set()},
     )
     assert actual[0] == example
@@ -644,6 +679,7 @@ def test_check_id_format(name, check_action, error_count):
                 languages={
                     "a": Language(
                         name="a",
+                        property="a",
                         versions=[
                             Version(
                                 sdk_version=1,
@@ -660,6 +696,7 @@ def test_check_id_format(name, check_action, error_count):
                 languages={
                     "a": Language(
                         name="a",
+                        property="a",
                         versions=[
                             Version(
                                 sdk_version=2,
@@ -669,6 +706,7 @@ def test_check_id_format(name, check_action, error_count):
                     ),
                     "b": Language(
                         name="b",
+                        property="b",
                         versions=[
                             Version(
                                 sdk_version=1,
@@ -685,6 +723,7 @@ def test_check_id_format(name, check_action, error_count):
                 languages={
                     "a": Language(
                         name="a",
+                        property="a",
                         versions=[
                             Version(
                                 sdk_version=1,
@@ -698,6 +737,7 @@ def test_check_id_format(name, check_action, error_count):
                     ),
                     "b": Language(
                         name="b",
+                        property="b",
                         versions=[
                             Version(
                                 sdk_version=1,
@@ -711,7 +751,7 @@ def test_check_id_format(name, check_action, error_count):
         )
     ],
 )
-def test_merge(a: Language, b: Language, d: Language):
+def test_merge(a: Example, b: Example, d: Example):
     a.merge(b, MetadataErrors())
     assert a == d
 
@@ -726,6 +766,7 @@ def test_merge(a: Language, b: Language, d: Language):
                 languages={
                     "a": Language(
                         name="a",
+                        property="a",
                         versions=[
                             Version(
                                 sdk_version=1,
@@ -741,6 +782,7 @@ def test_merge(a: Language, b: Language, d: Language):
                 languages={
                     "a": Language(
                         name="a",
+                        property="a",
                         versions=[
                             Version(
                                 sdk_version=1,
@@ -756,6 +798,7 @@ def test_merge(a: Language, b: Language, d: Language):
                 languages={
                     "a": Language(
                         name="a",
+                        property="a",
                         versions=[
                             Version(
                                 sdk_version=1,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds doc_filenames prop to Example class. The immediate need for this is to make these names available to the JS SDK API ref, but it could potentially be the source of truth for a python Zexi as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
