### PR TITLE
Remove caplog fixture

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen_cli_test.py
+++ b/aws_doc_sdk_examples_tools/doc_gen_cli_test.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch, mock_open
 from argparse import Namespace
+import logging
 from .doc_gen import DocGen, MetadataError
 from .doc_gen_cli import main
 
@@ -28,7 +29,7 @@ def patched_environment(mock_doc_gen):
 
 
 @pytest.mark.parametrize("strict,should_raise", [(True, True), (False, False)])
-def test_doc_gen_strict_option(strict, should_raise, patched_environment, caplog):
+def test_doc_gen_strict_option(strict, should_raise, patched_environment):
     mock_parse_args, mock_json_dump = patched_environment
     mock_args = Namespace(
         from_root=["/mock/path"], write_json="mock_output.json", strict=strict
@@ -39,8 +40,5 @@ def test_doc_gen_strict_option(strict, should_raise, patched_environment, caplog
         with pytest.raises(SystemExit) as exc_info:
             main()
         assert exc_info.value.code == 1
-        assert "Errors found in metadata" in caplog.text
-        assert "Error 1" in caplog.text
-        assert "Error 2" in caplog.text
     else:
         main()


### PR DESCRIPTION
*Description of changes:*
Remove caplog. Caplog was introduced in pytest 3.3.0. We're tied to 3.2.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
