### PR TITLE
Add validation check to block duplicate title_abbrev in the same language:version.

### DIFF
--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -324,8 +324,8 @@ class Example:
             guide_topic = None
 
         parsed_services = parse_services(yaml.get("services", {}), errors, services)
-        category = yaml.get("category")
-        if category is None or category == "":
+        category = yaml.get("category", "")
+        if category == "":
             category = "Api" if len(parsed_services) == 1 else "Cross"
         is_action = category == "Api"
 
@@ -489,7 +489,7 @@ def parse(
 ) -> tuple[List[Example], MetadataErrors]:
     examples: List[Example] = []
     errors = MetadataErrors()
-    validation = ValidationConfig() if validation is None else validation
+    validation = validation or ValidationConfig()
     for id in yaml:
         example, example_errors = Example.from_yaml(
             yaml[id], sdks, services, blocks, validation

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -323,6 +323,15 @@ class DuplicateAPIExample(MetadataError):
 
 
 @dataclass
+class DuplicateTitleAbbrev(MetadataError):
+    title_abbrev: str = ""
+    language: str = ""
+
+    def message(self):
+        return f"multiple API examples found with conflicting title_abbrev: {self.title_abbrev} in {self.language}"
+
+
+@dataclass
 class URLMissingTitle(SdkVersionError):
     url: str = ""
 

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -15,7 +15,7 @@ class MetadataError:
     id: Optional[str] = None
 
     def prefix(self):
-        prefix = f"In {self.file} at {self.id},"
+        prefix = f"In {self.file or 'several'} at {self.id},"
         return prefix
 
     def message(self) -> str:
@@ -328,7 +328,7 @@ class DuplicateTitleAbbrev(MetadataError):
     language: str = ""
 
     def message(self):
-        return f"multiple API examples found with conflicting title_abbrev: {self.title_abbrev} in {self.language}"
+        return f"multiple examples found with conflicting title_abbrev: {self.title_abbrev} in {self.language}"
 
 
 @dataclass

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -862,23 +862,27 @@ def test_no_duplicate_title_abbrev():
         examples={
             "a": Example(
                 id="a",
-                file="a",
+                file=Path("a"),
                 title_abbrev="abbr",
+                category="cat",
                 languages={
                     "java": Language(
                         name="java", property="java", versions=[Version(sdk_version=1)]
                     )
                 },
+                services={"svc": set()},
             ),
             "b": Example(
                 id="b",
-                file="b",
+                file=Path("b"),
                 title_abbrev="abbr",
+                category="cat",
                 languages={
                     "java": Language(
                         name="java", property="java", versions=[Version(sdk_version=1)]
                     )
                 },
+                services={"svc": set(), "cvs": set()},
             ),
         },
     )
@@ -886,7 +890,7 @@ def test_no_duplicate_title_abbrev():
 
     expected = [
         metadata_errors.DuplicateTitleAbbrev(
-            id="a, b", title_abbrev="abbr", language="java:1"
+            id="a, b", title_abbrev="abbr", language="svc:cat"
         )
     ]
 


### PR DESCRIPTION
This applies during late validation, so merging tributaries can cause it, even if it doesn't happen in each tributary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
