### PR TITLE
Remove a print and put expansion error exit behind args.strict

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen_cli.py
+++ b/aws_doc_sdk_examples_tools/doc_gen_cli.py
@@ -56,7 +56,6 @@ def main():
         # Replace entities
         for example in merged_doc_gen.examples.values():
             errors = EntityErrors()
-            print(example)
             title, title_errors = merged_doc_gen.expand_entities(example.title)
             errors.extend(title_errors)
 
@@ -76,7 +75,7 @@ def main():
                 synopsis_list.append(expanded_synopsis)
                 errors.extend(synopsis_errors)
 
-            if errors:
+            if args.strict and errors:
                 logging.error(
                     f"Errors expanding entities for example: {example}. {errors}"
                 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A rogue print got through, and I realized expansion errors should also be behind the strict flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
