### PR TITLE
Error on missing entities, replace on empty entities.

### DIFF
--- a/aws_doc_sdk_examples_tools/entities.py
+++ b/aws_doc_sdk_examples_tools/entities.py
@@ -87,7 +87,7 @@ def expand_entity(
     entity: str, entity_map: Dict[str, str]
 ) -> Tuple[str, Optional[EntityError]]:
     expanded = entity_map.get(entity)
-    if expanded:
+    if expanded is not None:
         return entity.replace(entity, expanded), None
     else:
-        return "", MissingEntityError(entity)
+        return entity, MissingEntityError(entity)

--- a/aws_doc_sdk_examples_tools/entities_test.py
+++ b/aws_doc_sdk_examples_tools/entities_test.py
@@ -17,11 +17,10 @@ def test_entity_errors_append():
         errors.append("invalid item")
 
 
-def test_expand_all_entities():
+def test_expand_missing_entities():
     entity_map = {
         "&entity1;": "expanded1",
         "&entity2;": "expanded2",
-        "&entity3;": "",
     }
 
     text = "This is a text with &entity1; and &entity2; and &entity3;"
@@ -32,6 +31,18 @@ def test_expand_all_entities():
     assert isinstance(errors._errors[0], MissingEntityError)
     assert errors._errors[0].entity == "&entity3;"
 
+def test_expand_empty_entity():
+    entity_map = {
+        "&entity1;": "expanded1",
+        "&entity2;": "expanded2",
+        "&entity3;": ""
+    }
+
+    text = "This is a text with &entity1; and &entity2; and &entity3;"
+    expanded_text, errors = expand_all_entities(text, entity_map)
+
+    assert expanded_text == "This is a text with expanded1 and expanded2 and "
+    assert len(errors._errors) == 0
 
 def test_expand_all_entities_with_no_entities():
     entity_map = {

--- a/aws_doc_sdk_examples_tools/entities_test.py
+++ b/aws_doc_sdk_examples_tools/entities_test.py
@@ -31,18 +31,16 @@ def test_expand_missing_entities():
     assert isinstance(errors._errors[0], MissingEntityError)
     assert errors._errors[0].entity == "&entity3;"
 
+
 def test_expand_empty_entity():
-    entity_map = {
-        "&entity1;": "expanded1",
-        "&entity2;": "expanded2",
-        "&entity3;": ""
-    }
+    entity_map = {"&entity1;": "expanded1", "&entity2;": "expanded2", "&entity3;": ""}
 
     text = "This is a text with &entity1; and &entity2; and &entity3;"
     expanded_text, errors = expand_all_entities(text, entity_map)
 
     assert expanded_text == "This is a text with expanded1 and expanded2 and "
     assert len(errors._errors) == 0
+
 
 def test_expand_all_entities_with_no_entities():
     entity_map = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Return errors if an entity is missing from the entity map during expansion. Treat empty strings as valid for entity expansion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
