### PR TITLE
Validate that github path items are reachable from the root

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -226,6 +226,7 @@ class DocGen:
                 self.services,
                 self.cross_blocks,
                 self.validation,
+                self.root,
             )
             self.extend_examples(examples, self.errors)
             self.errors.extend(errs)
@@ -264,6 +265,14 @@ class DocGen:
             self.errors,
             self.root,
         )
+
+    def validate_links(self):
+        for example in self.examples.values():
+            for language in example.languages.values():
+                for version in language.versions:
+                    if version.github:
+                        if not (self.root / version.github).exists():
+                            self.errors.append()
 
     def stats(self):
         values = self.examples.values()

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -266,14 +266,6 @@ class DocGen:
             self.root,
         )
 
-    def validate_links(self):
-        for example in self.examples.values():
-            for language in example.languages.values():
-                for version in language.versions:
-                    if version.github:
-                        if not (self.root / version.github).exists():
-                            self.errors.append()
-
     def stats(self):
         values = self.examples.values()
         initial = defaultdict(int)

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -237,6 +237,15 @@ class InvalidGithubLink(SdkVersionError):
 
 
 @dataclass
+class MissingGithubLink(SdkVersionError):
+    link: str = ""
+    root: Optional[Path] = None
+
+    def message(self):
+        return f"has link {self.link}, which is not a folder in this project (root: {self.root})."
+
+
+@dataclass
 class InvalidSdkGuideStart(SdkVersionError):
     guide: str = ""
 

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -106,8 +106,6 @@ medical-imaging_CreateDatastore:
      C++:
        versions:
          - sdk_version: 1
-           github: cpp/example_code/medical-imaging
-           sdkguide: sdkguide/link
            excerpts:
              - description: test excerpt description
                snippet_tags:
@@ -134,8 +132,6 @@ def test_parse():
         versions=[
             Version(
                 sdk_version=1,
-                github="cpp/example_code/medical-imaging",
-                sdkguide="sdkguide/link",
                 excerpts=[
                     Excerpt(
                         description="test excerpt description",
@@ -197,8 +193,6 @@ medical-imaging_GoodOne:
      C++:
        versions:
          - sdk_version: 1
-           github: cpp/example_code/medical-imaging
-           sdkguide: sdkguide/link
            excerpts:
              - description: test excerpt description
                snippet_tags:
@@ -214,8 +208,6 @@ medical-imaging_GoodScenario:
      C++:
        versions:
          - sdk_version: 1
-           github: cpp/example_code/medical-imaging
-           sdkguide: sdkguide/link
            excerpts:
              - description: test excerpt description
                snippet_tags:
@@ -243,8 +235,6 @@ def test_parse_strict_titles():
         versions=[
             Version(
                 sdk_version=1,
-                github="cpp/example_code/medical-imaging",
-                sdkguide="sdkguide/link",
                 excerpts=[
                     Excerpt(
                         description="test excerpt description",
@@ -326,8 +316,6 @@ medical-imaging_BadOne:
      C++:
        versions:
          - sdk_version: 1
-           github: cpp/example_code/medical-imaging
-           sdkguide: sdkguide/link
            excerpts:
              - description: test excerpt description
                snippet_tags:
@@ -340,8 +328,6 @@ medical-imaging_BadScenario:
      C++:
        versions:
          - sdk_version: 1
-           github: cpp/example_code/medical-imaging
-           sdkguide: sdkguide/link
            excerpts:
              - description: test excerpt description
                snippet_tags:
@@ -482,7 +468,7 @@ def test_verify_load_successful():
         versions=[
             Version(
                 sdk_version=2,
-                github="javav2/example_code/medical-imaging",
+                github="test_path",
                 block_content="test block",
                 excerpts=[],
                 add_services={},
@@ -498,7 +484,6 @@ def test_verify_load_successful():
         versions=[
             Version(
                 sdk_version=3,
-                github=None,
                 block_content=None,
                 add_services={"s3": set()},
                 excerpts=[
@@ -523,7 +508,6 @@ def test_verify_load_successful():
         versions=[
             Version(
                 sdk_version=3,
-                github="php/example_code/medical-imaging",
                 sdkguide="php/sdkguide/link",
                 block_content=None,
                 excerpts=[
@@ -648,6 +632,14 @@ FORMATTER_METADATA_PATH = (
                     language="Perl",
                     guide="https://docs.aws.amazon.com/absolute/link-to-my-guide",
                     sdk_version=1,
+                ),
+                metadata_errors.MissingGithubLink(
+                    file=ERRORS_METADATA_PATH,
+                    id="sqs_WrongServiceSlug",
+                    language="Perl",
+                    sdk_version=1,
+                    link="perl/example_code/medical-imaging",
+                    root=ERRORS_METADATA_PATH.parent,
                 ),
                 metadata_errors.MissingBlockContentAndExcerpt(
                     file=ERRORS_METADATA_PATH,

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -378,6 +378,14 @@ def test_parse_strict_title_errors():
             file=Path("test_cpp.yaml"),
             id="medical-imaging_BadBasics",
         ),
+        metadata_errors.MissingGithubLink(
+            file=Path("test_cpp.yaml"),
+            id="medical-imaging_BadBasics",
+            language="C++",
+            sdk_version=1,
+            link="cpp/example_code/medical-imaging",
+            root=Path("."),
+        ),
     ]
     assert expected == [*errors]
 

--- a/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
@@ -94,6 +94,5 @@ medical-imagingBadFormat:
     Java:
       versions:
         - sdk_version: 2
-          github: github/link
   services:
     medical-imaging: { TestAction }

--- a/aws_doc_sdk_examples_tools/test_resources/formaterror_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/formaterror_metadata.yaml
@@ -8,9 +8,8 @@ WrongNameFormat:
       versions:
         - sdk_version: 2
           block_content: test/block
-          github: javav2/example_code/medical-imaging
   services:
-    medical-imaging: {TestAction}
+    medical-imaging: { TestAction }
 cross_TestExample:
   title: Test title
   title_abbrev: Test title abbrev
@@ -23,5 +22,5 @@ cross_TestExample:
           add_services:
             garbage:
   services:
-    medical-imaging: {TestAction}
-    sqs: {TestAction}
+    medical-imaging: { TestAction }
+    sqs: { TestAction }

--- a/aws_doc_sdk_examples_tools/test_resources/test_path/snippet_file.txt
+++ b/aws_doc_sdk_examples_tools/test_resources/test_path/snippet_file.txt
@@ -1,0 +1,1 @@
+snippet file

--- a/aws_doc_sdk_examples_tools/test_resources/valid_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/valid_metadata.yaml
@@ -13,7 +13,7 @@ medical-imaging_TestExample:
     Java:
       versions:
         - sdk_version: 2
-          github: javav2/example_code/medical-imaging
+          github: test_path
           block_content: test block
     JavaScript:
       versions:
@@ -29,7 +29,6 @@ medical-imaging_TestExample:
     PHP:
       versions:
         - sdk_version: 3
-          github: php/example_code/medical-imaging
           sdkguide: php/sdkguide/link
           excerpts:
             - description: Optional description.


### PR DESCRIPTION
Validate that `github` path items are reachable from the root of the doc_gen parse call.

`github` properties in language versions entries are later turned into URLs in the final guide; this validation is a layer against them becoming 404s.

Closes #67 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
