### PR TITLE
Add validation for Basics example metadata.

### DIFF
--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -320,6 +320,7 @@ class Example:
         if category == "":
             category = "Api" if len(parsed_services) == 1 else "Cross"
         is_action = category == "Api"
+        is_basics = category == "Basics"
 
         if is_action:
             svc_actions = []
@@ -337,6 +338,10 @@ class Example:
             if is_action:
                 if title or title_abbrev or synopsis or synopsis_list:
                     errors.append(metadata_errors.APICannotHaveTitleFields())
+            elif is_basics:
+                # Basics examples can have custom titles or no titles (in this case they're generated).
+                if not (synopsis or synopsis_list):
+                    errors.append(metadata_errors.BasicsMustHaveSynopsisField())
             else:
                 if not (title and title_abbrev and (synopsis or synopsis_list)):
                     errors.append(metadata_errors.NonAPIMustHaveTitleFields())

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -280,6 +280,7 @@ class NonAPIMustHaveTitleFields(MetadataParseError):
             "Non-API examples must define these fields."
         )
 
+
 @dataclass
 class BasicsMustHaveSynopsisField(MetadataParseError):
     def message(self):
@@ -287,6 +288,7 @@ class BasicsMustHaveSynopsisField(MetadataParseError):
             "is a Basics example and does not define synopsis or synopsis_list. "
             "Basics examples must define one of these fields."
         )
+
 
 @dataclass
 class MissingSnippetTag(SdkVersionError):

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -280,6 +280,13 @@ class NonAPIMustHaveTitleFields(MetadataParseError):
             "Non-API examples must define these fields."
         )
 
+@dataclass
+class BasicsMustHaveSynopsisField(MetadataParseError):
+    def message(self):
+        return (
+            "is a Basics example and does not define synopsis or synopsis_list. "
+            "Basics examples must define one of these fields."
+        )
 
 @dataclass
 class MissingSnippetTag(SdkVersionError):

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -390,7 +390,7 @@ def test_parse_strict_title_errors():
         ),
         metadata_errors.BasicsMustHaveSynopsisField(
             file=Path("test_cpp.yaml"),
-            id="medical-imagine_BadBasics",
+            id="medical-imaging_BadBasics",
         )
     ]
     assert expected == [*errors]

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -348,6 +348,20 @@ medical-imaging_BadScenario:
                  - test.excerpt
    services:
      medical-imaging: {BadOne}
+medical-imaging_BadBasics:
+   category: Basics
+   languages:
+     C++:
+       versions:
+         - sdk_version: 1
+           github: cpp/example_code/medical-imaging
+           sdkguide: sdkguide/link
+           excerpts:
+             - description: test excerpt description
+               snippet_tags:
+                 - test.excerpt
+   services:
+     medical-imaging: {BadOne}
 """
 
 
@@ -374,6 +388,10 @@ def test_parse_strict_title_errors():
             file=Path("test_cpp.yaml"),
             id="medical-imaging_BadScenario",
         ),
+        metadata_errors.BasicsMustHaveSynopsisField(
+            file=Path("test_cpp.yaml"),
+            id="medical-imagine_BadBasics",
+        )
     ]
     assert expected == [*errors]
 

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -391,7 +391,7 @@ def test_parse_strict_title_errors():
         metadata_errors.BasicsMustHaveSynopsisField(
             file=Path("test_cpp.yaml"),
             id="medical-imaging_BadBasics",
-        )
+        ),
     ]
     assert expected == [*errors]
 


### PR DESCRIPTION
Add validation for Basics examples:

* They can optionally have `title` and `title_abbrev` (if not these fields are generated by downstream tools).
* They are required to have at least one of `synopsis` or `synopsis_list`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
