### PR TITLE
Handle python3.12 deprecation warnings.

### DIFF
--- a/aws_doc_sdk_examples_tools/config/services_schema.yaml
+++ b/aws_doc_sdk_examples_tools/config/services_schema.yaml
@@ -5,7 +5,7 @@ map(include('service'), key=regex('^[-a-z0-9]+$', name='service slug'))
 service:
   long: include('long_entity_regex')
   short: include('entity_regex')
-  sort: regex('^[^&]\w', name='non-entity')
+  sort: regex('^[^&]\\w', name='non-entity')
   chapter_override: include('chapter_override', required=False)
   expanded:
     long: str(upper_start=True, end_punc=False, check_aws=False)
@@ -25,6 +25,6 @@ chapter_override:
   title: str(end_punc=False)
   title_abbrev: str(end_punc=False)
 
-long_entity_regex: regex('^&[-_a-zA-Z0-9]+;( \(&[-_a-zA-Z0-9]+;\))?$', name='valid entity')
+long_entity_regex: regex('^&[-_a-zA-Z0-9]+;( \\(&[-_a-zA-Z0-9]+;\\))?$', name='valid entity')
 entity_regex: regex('^&[-_a-zA-Z0-9]+;$', name='valid entity')
 doc_url: regex('^(?!https://docs.aws.amazon.com/).+', name="relative documentation URL")


### PR DESCRIPTION
These are backwards compatible to Python 3.8, and are mildly annoying.

```
E           SyntaxError: Schema error in file /Users/dpsouth/devel/aws/aws-doc-sdk-examples-tools/aws_doc_sdk_examples_tools/config/services_schema.yaml
E           Invalid schema expression: 'regex('^[^&]\w', name='non-entity')'. invalid escape sequence \w (<unknown>, line 1) at node 'sort'  E           SyntaxError: Schema error in file /Users/dpsouth/devel/aws/aws-doc-sdk-examples-tools/aws_doc_sdk_examples_tools/config/services_schema.yaml
E           Invalid schema expression: 'regex('^&[-_a-zA-Z0-9]+;( \(&[-_a-zA-Z0-9]+;\))?$', name='valid entity')'. invalid escape sequence \( (<unknown>, line 1) at node '' 
E           SyntaxError: Schema error in file /Users/dpsouth/devel/aws/aws-doc-sdk-examples-tools/aws_doc_sdk_examples_tools/config/services_schema.yaml
E           Invalid schema expression: 'regex('^&[-_a-zA-Z0-9]+;( \\(&[-_a-zA-Z0-9]+;\))?$', name='valid entity')'. invalid escape sequence \) (<unknown>, line 1) at node ''
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
