### PR TITLE
Skip github path check for full path links.

### DIFF
--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -120,6 +120,8 @@ class Version:
                         link=github, sdk_version=sdk_version
                     )
                 )
+            elif github.startswith("http"):
+                pass  # Tributaries specify full GitHub path. Consider passing in GitHub root from tributaries and doing a full check at some point.
             elif not (root / github).exists():
                 errors.append(
                     metadata_errors.MissingGithubLink(


### PR DESCRIPTION
Tributaries specify full path for GitHub links, so this check is failing those.
This fixes the failure for now. We should consider doing a full check on these at some point.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
