### PR TITLE
Perform github path check during validation, rather than metadata parsing.

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -256,6 +256,8 @@ class DocGen:
             sdk.validate(self.errors)
         for service in self.services.values():
             service.validate(self.errors)
+        for example in self.examples.values():
+            example.validate(self.errors, self.root)
         validate_metadata(self.root, self.errors)
         validate_no_duplicate_api_examples(self.examples.values(), self.errors)
         validate_snippets(


### PR DESCRIPTION
Downstream users of DocGen often load the metadata separately from the original file, which is a problem when the excerpt github link checks against an actual path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
