### PR TITLE
Remove bookmark override link from Java SDK metadata

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -150,7 +150,6 @@ Java:
         long: "AWS SDK for Java 2.x"
         short: "SDK for Java 2.x"
       guide: "sdk-for-java/latest/developer-guide/home.html"
-      bookmark: readme
       api_ref:
         uid: "SdkForJavaV2"
         name: "&guide-javaV2-api;"


### PR DESCRIPTION
Now that Java examples are mostly using the standard README format, this custom bookmark is no longer needed. This custom bookmark was also breaking tributary's ability to include their own bookmark links.

* For examples in WRITEME format, the bookmark link works as expected by scrolling down to the _Code examples_ section.
* For examples in non-standard README format, the bookmark is ignored and link goes to the top of the file. This is acceptable.
* For tributaries that use their own GitHub URLs, they can add a bookmark and have it work as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
