### PR TITLE
Meta: Remove Swift prerelease caveat.

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -287,7 +287,6 @@ Swift:
     1:
       long: "&Swiftlong;"
       short: "&Swift;"
-      caveat: "This is prerelease documentation for an SDK in preview release. It is subject to change."
       expanded:
         long: "AWS SDK for Swift"
         short: "SDK for Swift"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="aws_doc_sdk_examples_tools",
-    version="1.0.4+2024-09-19-A",
+    version="1.0.4+2024-09-20-A",
     packages=["aws_doc_sdk_examples_tools"],
     package_data={"aws_doc_sdk_examples_tools": ["config/*.yaml"]},
     entry_points={


### PR DESCRIPTION
Swift SDK is now GA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
