### PR TITLE
DocGen: changes to correctly merge metadata from tributaries

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -114,6 +114,8 @@ class DocGen:
                     )
                 )
 
+        self.validation.allow_list.update(other.validation.allow_list)
+        self.validation.sample_files.update(other.validation.sample_files)
         self.snippet_files.update(other.snippet_files)
         self.cross_blocks.update(other.cross_blocks)
         self.extend_examples(other.examples.values(), warnings)
@@ -134,7 +136,7 @@ class DocGen:
 
     @classmethod
     def default(cls) -> "DocGen":
-        return DocGen.empty().for_root(Path(__file__).parent)
+        return DocGen.empty().for_root(Path(__file__).parent, incremental=True)
 
     def clone(self) -> "DocGen":
         return DocGen(


### PR DESCRIPTION
This PR adds a few things to let update-mirror correctly merge services, SDKs, and validation metadata from tributaries. With upcoming update-mirror changes, this fully enables the feature that lets tributaries define their own services.yaml, sdks.yaml, and validation.yaml.

* Adds `incremental=true` to DocGen `default` so it does loads the default metadata from itself but does not try to load any examples. This defines the "default" DocGen as containing all of the services, SDKs, and validation lists defined in this repo so that it can be used as a basis for merging in tributary examples and additional services, SDKs, and validation.
* Update `DocGen.merge` to merge validation data from `other`.

With these changes, update-mirror can then:

1. Load a default DocGen.
2. Merge metadata from a tributary and successfully validate it against the base services, etc., as well as the tributary add-ons.
3. Merge each tributary into the full registry of metadata.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
