### PR TITLE
Use branch --show-current for current branch name

### DIFF
--- a/stamp.sh
+++ b/stamp.sh
@@ -4,7 +4,7 @@ set -e # Exit on errors
 # set -x # Shell debugging
 
 # First, check that we're on the main branch.
-BRANCH=$(git rev-parse --abbrev-rev HEAD)
+BRANCH=$(git branch --show-current)
 if [ "$BRANCH" != "main" ] ; then 
     echo "Not on main, exiting!" 
     exit 1


### PR DESCRIPTION
rev-parse came from ChatGPT and it only works _sometimes_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
