### PR TITLE
Meta: Add JavaScript runtime for CloudFront Functions to sdks.yaml.

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -178,6 +178,28 @@ JavaScript:
         uid: "AWSJavaScriptSDKV3"
         name: "&guide-jsb-api;"
         link_template: "AWSJavaScriptSDK/v3/latest/client/{{.Service}}/command/{{.Action}}Command"
+    101:
+      long: "&CFJS10long;"
+      short: "&CFJS10;"
+      expanded:
+        long: JavaScript runtime 1.0 for Amazon CloudFront Functions
+        short: JavaScript runtime 1.0 for CloudFront Functions
+      guide: AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html
+      api_ref:
+        uid: "cloudfront"
+        name: "&guide-cf-api;"
+        link_template: "https://docs.aws.amazon.com/cloudfront/latest/APIReference/Welcome.html"
+    102:
+      long: "&CFJS20long;"
+      short: "&CFJS20;"
+      expanded:
+        long: JavaScript runtime 2.0 for Amazon CloudFront Functions
+        short: JavaScript runtime 2.0 for CloudFront Functions
+      guide: AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html
+      api_ref:
+        uid: "cloudfront"
+        name: "&guide-cf-api;"
+        link_template: "https://docs.aws.amazon.com/cloudfront/latest/APIReference/Welcome.html"
   guide: "&guide-jsb-dev;"
 Kotlin:
   property: kotlin


### PR DESCRIPTION
This PR adds entries to sdks.yaml to support publishing examples for the JavaScript runtime for CloudFront Funcions.

This is a stopgap mechanism to let us publish these specific examples until we rework the metadata to better support examples that are outside the scope of standard AWS SDKs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
