### PR TITLE
Meta: S3 directory bucket subservice

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -122,6 +122,7 @@ Go:
           route-53-domains: route53domains
           route53-recovery-cluster: route53recoverycluster
           s3-control: s3control
+          s3-directory-buckets: s3
           secrets-manager: secretsmanager
           service-catalog: servicecatalog
           service-catalog-appregistry: servicecatalogappregistry

--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -376,6 +376,7 @@ CLI:
           route-53-domains: route53domains
           s3: s3api
           s3-control: s3control
+          s3-directory-buckets: s3api
           secrets-manager: secretsmanager
           serverlessapplicationrepository: serverlessrepo
           service-catalog: servicecatalog

--- a/aws_doc_sdk_examples_tools/config/services.yaml
+++ b/aws_doc_sdk_examples_tools/config/services.yaml
@@ -2776,15 +2776,15 @@ s3-control:
 s3-directory-buckets:
   bundle: s3
   api_ref: AmazonS3/latest/API/Welcome.html
-  blurb: are a high-performance, single-zone Amazon S3 storage class that is purpose-built to deliver consistent, single-digit millisecond data access for your most latency-sensitive applications.
+  blurb: are designed to store data within a single AWS Zone. Directory buckets organize data hierarchically into directories, providing a structure similar to a file system.
   expanded:
     long: Amazon S3 Directory Buckets
-    short: Amazon S3 Directory Buckets
+    short: S3 Directory Buckets
   guide:
     subtitle: User Guide
-    url: AmazonS3/latest/userguide/s3-express-one-zone.html
+    url: AmazonS3/latest/userguide/directory-buckets-overview.html
   long: '&S3; Directory Buckets'
-  short: '&S3; Directory Buckets'
+  short: '&S3only; Directory Buckets'
   sort: S3 Directory Buckets
   tags:
     product_categories: {'Storage'}

--- a/aws_doc_sdk_examples_tools/config/services.yaml
+++ b/aws_doc_sdk_examples_tools/config/services.yaml
@@ -2773,6 +2773,22 @@ s3-control:
   tags:
     product_categories: {'Storage'}
   version: s3control-2018-08-20
+s3-directory-buckets:
+  bundle: s3
+  api_ref: AmazonS3/latest/API/Welcome.html
+  blurb: are a high-performance, single-zone Amazon S3 storage class that is purpose-built to deliver consistent, single-digit millisecond data access for your most latency-sensitive applications.
+  expanded:
+    long: Amazon S3 Directory Buckets
+    short: Amazon S3 Directory Buckets
+  guide:
+    subtitle: User Guide
+    url: AmazonS3/latest/userguide/s3-express-one-zone.html
+  long: '&S3; Directory Buckets'
+  short: '&S3; Directory Buckets'
+  sort: S3 Directory Buckets
+  tags:
+    product_categories: {'Storage'}
+  version: s3-2006-03-01
 sagemaker:
   long: '&SMlong;'
   short: '&SM;'


### PR DESCRIPTION
Add s3-directory-buckets as a pseudo-subservice bundled under s3 so that its examples are published in a separate folder under s3 in the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
