### PR TITLE
Add validation to explicitly check for bare AWS strings in excerpt descriptions

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen_cli_test.py
+++ b/aws_doc_sdk_examples_tools/doc_gen_cli_test.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from .doc_gen import DocGen, MetadataError, Example
 from .doc_gen_cli import main
-from .metadata import DocFilenames, Sdk, Language, SDKPageVersion, Version
-from .sdks import SdkVersion
+from .metadata import DocFilenames, Language, SDKPageVersion, Version
+from .sdks import Sdk, SdkVersion
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def mock_example():
             },
             sdk_pages={
                 "cpp": {
-                    1: SDKPageVersion(actions_scenarios={"medical-imaging": f"link"})
+                    1: SDKPageVersion(actions_scenarios={"medical-imaging": "link"})
                 }
             },
         ),

--- a/aws_doc_sdk_examples_tools/project_validator.py
+++ b/aws_doc_sdk_examples_tools/project_validator.py
@@ -24,7 +24,7 @@ import re
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Set
+from typing import Dict, List, Set
 
 from .file_utils import get_files
 from .metadata_errors import (
@@ -206,3 +206,20 @@ def verify_no_secret_keys(
     keys -= validation.allow_list
     for word in keys:
         errors.append(PossibleSecretKey(file=file_location, word=word))
+
+
+@dataclass
+class InvalidBareAWS(MetadataError):
+    content: str = ""
+    path: str = ""
+
+    def message(self):
+        return f"Possible bare AWS in {self.path} ({self.content})"
+
+
+BARE_AWS_REGEX = r"\bAWS\s+[A-Za-z0-9]+\b"
+
+
+def verify_no_invalid_bare_aws(content: str, path: str, errors: MetadataErrors):
+    if re.findall(BARE_AWS_REGEX, content):
+        errors.append(InvalidBareAWS(content=content, path=path))


### PR DESCRIPTION
There is technically more nuance, but this has caused more problems being loose than restrictive.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
