### PR TITLE
Update link_template for Swift in sdks.yaml

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -317,7 +317,7 @@ Swift:
       api_ref:
         uid: "SdkForSwift"
         name: "&guide-swift-api;"
-        link_template: "https://github.com/awslabs/aws-sdk-swift"
+        link_template: "https://sdk.amazonaws.com/swift/api/awssdkforswift/latest/documentation/awssdkforswift"
   guide: "&guide-swift-dev;"
 CLI:
   property: cli

--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -317,7 +317,7 @@ Swift:
       api_ref:
         uid: "SdkForSwift"
         name: "&guide-swift-api;"
-        link_template: "https://awslabs.github.io/aws-sdk-swift/reference/0.x"
+        link_template: "https://github.com/awslabs/aws-sdk-swift"
   guide: "&guide-swift-dev;"
 CLI:
   property: cli


### PR DESCRIPTION
The link to `https://awslabs.github.io/aws-sdk-swift/reference/0.x` in the existing template is a 404. Fixed to https://github.com/awslabs/aws-sdk-swift, which is a current Swift SDK.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
