### PR TITLE
validator: Remove example ID check from yamale validator

### DIFF
--- a/aws_doc_sdk_examples_tools/metadata_validator.py
+++ b/aws_doc_sdk_examples_tools/metadata_validator.py
@@ -81,11 +81,7 @@ class ExampleId(Validator):
         return "valid example ID"
 
     def _is_valid(self, value: str):
-        if not re.fullmatch("^[\\da-z-]+(_[\\da-zA-Z]+)+$", value):
-            return False
-        else:
-            svc = value.split("_")[0]
-            return (svc == "cross") or (svc in self.services)
+        return re.fullmatch("^[\\da-z-]+(_[\\da-zA-Z-]+)+$", value)
 
 
 class BlockContent(Validator):


### PR DESCRIPTION
The yamale validation of the example ID is overly restrictive and we already check the example ID in a more flexible way in the main validator, so I'm removing this now superfluous code.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
