### PR TITLE
Generically handle all entities in DocGen entity expansion.

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen_cli.py
+++ b/aws_doc_sdk_examples_tools/doc_gen_cli.py
@@ -48,43 +48,13 @@ def main():
         unmerged_doc_gen = DocGen.from_root(Path(root))
         merged_doc_gen.merge(unmerged_doc_gen)
 
+    if not args.skip_entity_expansion:
+        # Replace entities
+        merged_doc_gen.expand_entity_fields(merged_doc_gen)
+
     if args.strict and merged_doc_gen.errors:
         logging.error("Errors found in metadata: %s", merged_doc_gen.errors)
         exit(1)
-
-    if not args.skip_entity_expansion:
-        # Replace entities
-        for example in merged_doc_gen.examples.values():
-            errors = EntityErrors()
-            title, title_errors = merged_doc_gen.expand_entities(example.title)
-            errors.extend(title_errors)
-
-            title_abbrev, title_abbrev_errors = merged_doc_gen.expand_entities(
-                example.title_abbrev
-            )
-            errors.extend(title_abbrev_errors)
-
-            synopsis, synopsis_errors = merged_doc_gen.expand_entities(example.synopsis)
-            errors.extend(synopsis_errors)
-
-            synopsis_list = []
-            for synopsis in example.synopsis_list:
-                expanded_synopsis, synopsis_errors = merged_doc_gen.expand_entities(
-                    synopsis
-                )
-                synopsis_list.append(expanded_synopsis)
-                errors.extend(synopsis_errors)
-
-            if args.strict and errors:
-                logging.error(
-                    f"Errors expanding entities for example: {example}. {errors}"
-                )
-                exit(1)
-
-            example.title = title
-            example.title_abbrev = title_abbrev
-            example.synopsis = synopsis
-            example.synopsis_list = synopsis_list
 
     serialized = json.dumps(merged_doc_gen, cls=DocGenEncoder)
 

--- a/aws_doc_sdk_examples_tools/entities.py
+++ b/aws_doc_sdk_examples_tools/entities.py
@@ -2,16 +2,16 @@ from typing import Optional, Dict, Set, Tuple
 from dataclasses import dataclass
 import re
 
-from .metadata_errors import ErrorsList
+from .metadata_errors import ErrorsList, MetadataError
 
 
 @dataclass
-class EntityError(Exception):
+class EntityError(MetadataError):
     """
     Base error. Do not use directly.
     """
 
-    entity: Optional[str]
+    entity: Optional[str] = None
 
     def message(self) -> str:
         return ""
@@ -54,4 +54,4 @@ def expand_entity(
     if expanded is not None:
         return entity.replace(entity, expanded), None
     else:
-        return entity, MissingEntityError(entity)
+        return entity, MissingEntityError(entity=entity)

--- a/aws_doc_sdk_examples_tools/entities_test.py
+++ b/aws_doc_sdk_examples_tools/entities_test.py
@@ -9,7 +9,7 @@ from .metadata_errors import InvalidItemException
 
 def test_entity_errors_append():
     errors = EntityErrors()
-    errors.append(MissingEntityError("entity1"))
+    errors.append(MissingEntityError(entity="entity1"))
     assert len(errors._errors) == 1
     assert errors._errors[0].entity == "entity1"
 


### PR DESCRIPTION
*Description of changes:*

Replace hand-rolled property lookup for expansion with a generic dataclass fields based approach.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
