### PR TITLE
Swift: Add direct-to-action link_template

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -317,7 +317,7 @@ Swift:
       api_ref:
         uid: "SdkForSwift"
         name: "&guide-swift-api;"
-        link_template: "https://sdk.amazonaws.com/swift/api/awssdkforswift/latest/documentation/awssdkforswift"
+        link_template: "https://sdk.amazonaws.com/swift/api/aws{{.ServiceCollapsed}}/latest/documentation/aws{{.ServiceCollapsed}}/{{.ServiceCollapsed}}client/{{.ActionLower}}(input:)"
   guide: "&guide-swift-dev;"
 CLI:
   property: cli


### PR DESCRIPTION
Updates sdks.yaml so Swift reference links go directly to action pages instead of always to the top page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
