### PR TITLE
Flexible SDK validation

### DIFF
--- a/aws_doc_sdk_examples_tools/config/example_schema.yaml
+++ b/aws_doc_sdk_examples_tools/config/example_schema.yaml
@@ -10,7 +10,7 @@ example:
   synopsis_list: list(str(upper_start=True), required=False)
   category: str(required=False, upper_start=True, no_end_punc=True)
   guide_topic: include('guide_topic', required=False)
-  languages: map(include('language'), key=enum('Bash', 'C++', 'CLI', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'PowerShell', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
+  languages: map(include('language'))
   service_main: service_name(required=False)
   services: map(key=service_name())
 

--- a/aws_doc_sdk_examples_tools/config/example_strict_schema.yaml
+++ b/aws_doc_sdk_examples_tools/config/example_strict_schema.yaml
@@ -10,7 +10,7 @@ example:
   synopsis_list: list(str(upper_start=True, end_punc=True), required=False)
   category: str(required=False, upper_start=True, no_end_punc=True)
   guide_topic: include('guide_topic', required=False)
-  languages: map(include('language'), key=enum('Bash', 'C++', 'CLI', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'PowerShell', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
+  languages: map(include('language'))
   service_main: service_name(required=False)
   services: map(map(key=str(), required=False), key=service_name())
 

--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -208,7 +208,7 @@ class DocGen:
             sdk_path = config / "sdks.yaml"
             with sdk_path.open(encoding="utf-8") as file:
                 meta = yaml.safe_load(file)
-                sdks, errs = parse_sdks(sdk_path, meta)
+                sdks, errs = parse_sdks(sdk_path, meta, self.validation.strict_titles)
                 self.sdks = sdks
                 self.errors.extend(errs)
         except Exception:

--- a/aws_doc_sdk_examples_tools/doc_gen_test.py
+++ b/aws_doc_sdk_examples_tools/doc_gen_test.py
@@ -12,7 +12,7 @@ import json
 from .categories import Category, TitleInfo
 from .doc_gen import DocGen, DocGenEncoder
 from .metadata import Example
-from .metadata_errors import MetadataErrors, MetadataError
+from .metadata_errors import MetadataErrors, MetadataError, UnknownLanguage
 from .sdks import Sdk, SdkVersion
 from .services import Service, ServiceExpanded
 from .snippets import Snippet
@@ -245,3 +245,12 @@ def test_fill_fields(sample_doc_gen: DocGen):
     assert example.title == "<code>PutObject</code>"
     assert example.title_abbrev == "ExcerptPartsUsage"
     assert example.synopsis == "&S3; PutObject"
+
+
+def test_language_not_in_sdks():
+    errors = MetadataErrors()
+    doc_gen = DocGen(Path(), errors).for_root(
+        Path(__file__).parent / "test_resources", incremental=False
+    )
+    doc_gen.process_metadata(doc_gen.root / "bad_language_example.yaml")
+    assert isinstance(doc_gen.errors[0], UnknownLanguage)

--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -86,7 +86,7 @@ class Version:
 @dataclass
 class Language:
     name: str
-    # A downcased, special-character-free version of the name. Matches a key of the same name in sdks.yaml.
+    # A downcased, special-character-free version of the name. Matches a key of the same name in sdks.yaml. Used for syntax parser.
     property: str
     versions: List[Version]
 

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -401,10 +401,10 @@ class ExampleMergeConflict(LanguageError):
         return f"conflict from {self.other_file}: example already exists for this language and SDK version"
 
 
-def check_mapping(mapping: str | None, field: str) -> str | MetadataParseError:
+def check_mapping(mapping: str | None, field: str, strict: bool = True) -> str | MetadataParseError:
     if not mapping:
         return MissingField(field=field)
-    if not re.match("&[-_a-zA-Z0-9]+;", mapping):
+    if strict and not re.match("&[-_a-zA-Z0-9]+;", mapping):
         return MappingMustBeEntity(field=field, value=mapping)
 
     return mapping

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -401,7 +401,9 @@ class ExampleMergeConflict(LanguageError):
         return f"conflict from {self.other_file}: example already exists for this language and SDK version"
 
 
-def check_mapping(mapping: str | None, field: str, strict: bool = True) -> str | MetadataParseError:
+def check_mapping(
+    mapping: str | None, field: str, strict: bool = True
+) -> str | MetadataParseError:
     if not mapping:
         return MissingField(field=field)
     if strict and not re.match("&[-_a-zA-Z0-9]+;", mapping):

--- a/aws_doc_sdk_examples_tools/metadata_validator_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_validator_test.py
@@ -29,12 +29,3 @@ def test_aws_entity_usage(strict):
     assert "Synopsis programlisting has AWS" not in e_str
     assert "Synopsis list code has <code>AWS" not in e_str
     assert "Description programlisting has AWS" not in e_str
-
-
-def test_sdk_property_syntax():
-    errors = MetadataErrors()
-    validate_metadata(Path(), True, errors)
-
-    e_str = str(errors)
-    assert "0 errors" in e_str
-

--- a/aws_doc_sdk_examples_tools/metadata_validator_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_validator_test.py
@@ -29,3 +29,12 @@ def test_aws_entity_usage(strict):
     assert "Synopsis programlisting has AWS" not in e_str
     assert "Synopsis list code has <code>AWS" not in e_str
     assert "Description programlisting has AWS" not in e_str
+
+
+def test_sdk_property_syntax():
+    errors = MetadataErrors()
+    validate_metadata(Path(), True, errors)
+
+    e_str = str(errors)
+    assert "0 errors" in e_str
+

--- a/aws_doc_sdk_examples_tools/sdks.py
+++ b/aws_doc_sdk_examples_tools/sdks.py
@@ -66,11 +66,11 @@ class SdkVersion:
 
     @classmethod
     def from_yaml(
-        cls, version: int, yaml: Dict[str, Any]
+        cls, version: int, yaml: Dict[str, Any], strict: bool
     ) -> tuple[SdkVersion, MetadataErrors]:
         errors = MetadataErrors()
-        long = check_mapping(yaml.get("long"), "long")
-        short = check_mapping(yaml.get("short"), "short")
+        long = check_mapping(yaml.get("long"), "long", strict)
+        short = check_mapping(yaml.get("short"), "short", strict)
         guide = yaml.get("guide")
         caveat = yaml.get("caveat")
         bookmark = yaml.get("bookmark")
@@ -141,7 +141,7 @@ class Sdk:
             errors.append(SdkWithNoVersionsError(id=self.name))
 
     @classmethod
-    def from_yaml(cls, name: str, yaml: Dict[str, Any]) -> tuple[Sdk, MetadataErrors]:
+    def from_yaml(cls, name: str, yaml: Dict[str, Any], strict: bool) -> tuple[Sdk, MetadataErrors]:
         errors = MetadataErrors()
         property = yaml.get("property", "")
         guide = check_mapping(yaml.get("guide"), "guide")
@@ -154,7 +154,7 @@ class Sdk:
         sdk_versions = sdk_versions or {}
         for version in sdk_versions:
             (sdk_version, errs) = SdkVersion.from_yaml(
-                int(version), sdk_versions[version]
+                int(version), sdk_versions[version], strict
             )
             versions.append(sdk_version)
             errors.extend(errs)
@@ -162,12 +162,12 @@ class Sdk:
         return cls(name=name, versions=versions, guide=guide, property=property), errors
 
 
-def parse(file: Path, yaml: Dict[str, Any]) -> tuple[Dict[str, Sdk], MetadataErrors]:
+def parse(file: Path, yaml: Dict[str, Any], strict: bool = True) -> tuple[Dict[str, Sdk], MetadataErrors]:
     sdks: Dict[str, Sdk] = {}
     errors = MetadataErrors()
 
     for name in yaml:
-        sdk, errs = Sdk.from_yaml(name, yaml[name])
+        sdk, errs = Sdk.from_yaml(name, yaml[name], strict)
         sdks[name] = sdk
         for error in errs:
             error.file = file

--- a/aws_doc_sdk_examples_tools/sdks.py
+++ b/aws_doc_sdk_examples_tools/sdks.py
@@ -141,7 +141,9 @@ class Sdk:
             errors.append(SdkWithNoVersionsError(id=self.name))
 
     @classmethod
-    def from_yaml(cls, name: str, yaml: Dict[str, Any], strict: bool) -> tuple[Sdk, MetadataErrors]:
+    def from_yaml(
+        cls, name: str, yaml: Dict[str, Any], strict: bool
+    ) -> tuple[Sdk, MetadataErrors]:
         errors = MetadataErrors()
         property = yaml.get("property", "")
         guide = check_mapping(yaml.get("guide"), "guide")
@@ -162,7 +164,9 @@ class Sdk:
         return cls(name=name, versions=versions, guide=guide, property=property), errors
 
 
-def parse(file: Path, yaml: Dict[str, Any], strict: bool = True) -> tuple[Dict[str, Sdk], MetadataErrors]:
+def parse(
+    file: Path, yaml: Dict[str, Any], strict: bool = True
+) -> tuple[Dict[str, Sdk], MetadataErrors]:
     sdks: Dict[str, Sdk] = {}
     errors = MetadataErrors()
 

--- a/aws_doc_sdk_examples_tools/sdks_test.py
+++ b/aws_doc_sdk_examples_tools/sdks_test.py
@@ -20,7 +20,9 @@ from .sdks import (
 )
 
 
-def load(path: str, strict: bool = True) -> Tuple[Dict[str, Sdk], metadata_errors.MetadataErrors]:
+def load(
+    path: str, strict: bool = True
+) -> Tuple[Dict[str, Sdk], metadata_errors.MetadataErrors]:
     root = Path(__file__).parent
     filename = root / "test_resources" / path
     with open(filename) as file:

--- a/aws_doc_sdk_examples_tools/sdks_test.py
+++ b/aws_doc_sdk_examples_tools/sdks_test.py
@@ -20,12 +20,12 @@ from .sdks import (
 )
 
 
-def load(path: str) -> Tuple[Dict[str, Sdk], metadata_errors.MetadataErrors]:
+def load(path: str, strict: bool = True) -> Tuple[Dict[str, Sdk], metadata_errors.MetadataErrors]:
     root = Path(__file__).parent
     filename = root / "test_resources" / path
     with open(filename) as file:
         meta = yaml.safe_load(file)
-    return parse(filename, meta)
+    return parse(filename, meta, strict)
 
 
 def test_empty_sdks():
@@ -164,6 +164,32 @@ def test_sdks():
         ),
     }
     assert actual == expected
+
+
+def test_pseudo_sdks():
+    actual, errs = load("pseudo_sdks.yaml", False)
+    expected = {
+        "IAMPolicy": Sdk(
+            name="IAMPolicy",
+            property="policy",
+            guide="&guide-iam-user;",
+            versions=[
+                SdkVersion(
+                    version=1,
+                    long="IAM policy long",
+                    short="IAM policy short",
+                    guide="IAM/latest/UserGuide/introduction.html",
+                    api_ref=SdkApiRef(
+                        uid="IAMPolicy",
+                        name="&SAZR;",
+                        link_template="https://docs.aws.amazon.com/service-authorization/latest/reference/reference.html",
+                    ),
+                )
+            ],
+        ),
+    }
+    assert actual == expected
+    assert len(errs) == 0
 
 
 if __name__ == "__main__":

--- a/aws_doc_sdk_examples_tools/test_resources/bad_language_example.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/bad_language_example.yaml
@@ -1,0 +1,14 @@
+s3_TestExample:
+  title: Test language not in SDKs
+  title_abbrev: Test language not in SDKs
+  synopsis: test language not in SDKs.
+  category: Test
+  languages:
+    NotAnSdk:
+      versions:
+        - sdk_version: 1
+          excerpts:
+            - snippet_tags:
+                - s3.notalang
+  services:
+    s3:

--- a/aws_doc_sdk_examples_tools/test_resources/pseudo_sdks.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/pseudo_sdks.yaml
@@ -1,0 +1,12 @@
+IAMPolicy:
+  property: policy
+  sdk:
+    1:
+      long: "IAM policy long"
+      short: "IAM policy short"
+      guide: "IAM/latest/UserGuide/introduction.html"
+      api_ref:
+        uid: "IAMPolicy"
+        name: "&SAZR;"
+        link_template: "https://docs.aws.amazon.com/service-authorization/latest/reference/reference.html"
+  guide: "&guide-iam-user;"

--- a/aws_doc_sdk_examples_tools/validate.py
+++ b/aws_doc_sdk_examples_tools/validate.py
@@ -44,13 +44,17 @@ def main():
         doc_gen = DocGen.default()
         doc_gen.merge(
             DocGen.from_root(
-                root=root_path, validation=ValidationConfig(strict_titles=args.strict_titles), config=config_path
+                root=root_path,
+                validation=ValidationConfig(strict_titles=args.strict_titles),
+                config=config_path,
             )
         )
         doc_gen.root = root_path
     else:
         doc_gen = DocGen.from_root(
-            root=root_path, validation=ValidationConfig(strict_titles=args.strict_titles), config=args.config
+            root=root_path,
+            validation=ValidationConfig(strict_titles=args.strict_titles),
+            config=args.config,
         )
 
     doc_gen.collect_snippets(snippets_root=root_path)

--- a/aws_doc_sdk_examples_tools/validate.py
+++ b/aws_doc_sdk_examples_tools/validate.py
@@ -32,12 +32,27 @@ def main():
         "must have them.",
         required=False,
     )
+    parser.add_argument(
+        "--config",
+        help="The path to the local config folder to use for validation in addition to the root config.",
+    )
     args = parser.parse_args()
     root_path = Path(args.root).resolve()
 
-    doc_gen = DocGen.from_root(
-        root=root_path, validation=ValidationConfig(strict_titles=args.strict_titles)
-    )
+    if args.config:
+        config_path = Path(args.config).resolve()
+        doc_gen = DocGen.default()
+        doc_gen.merge(
+            DocGen.from_root(
+                root=root_path, validation=ValidationConfig(strict_titles=args.strict_titles), config=config_path
+            )
+        )
+        doc_gen.root = root_path
+    else:
+        doc_gen = DocGen.from_root(
+            root=root_path, validation=ValidationConfig(strict_titles=args.strict_titles), config=args.config
+        )
+
     doc_gen.collect_snippets(snippets_root=root_path)
     doc_gen.validate()
     if not args.doc_gen_only:


### PR DESCRIPTION
This PR makes SDK validation more flexible, which lets us load SDKs defined by tributaries and validate them without requiring updates to schemas in this repo.

* Check SDK names (`language` fields) in examples against the dynamically loaded list of SDKs instead of enforcing the static list from the yamale schema.
* Pass the `strict` flag to the SDK validator and when it is `False`, allow non-entity name fields.
* Add a `--config` flag to `validate` so that a tributary can pass its config path to the validator. When this path is passed, the validator first loads default config (services, SDKs, etc.), then loads and merges the tributary config. In this way, the tributary validates its examples using the combined set of root + local config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
