### PR TITLE
For tributary validation, load things in the right order

### DIFF
--- a/aws_doc_sdk_examples_tools/doc_gen.py
+++ b/aws_doc_sdk_examples_tools/doc_gen.py
@@ -262,10 +262,13 @@ class DocGen:
             pass
 
         if not incremental:
-            for path in metadata.glob("*_metadata.yaml"):
-                self.process_metadata(path)
+            self.find_and_process_metadata(metadata)
 
         return self
+
+    def find_and_process_metadata(self, metadata_path: Path):
+        for path in metadata_path.glob("*_metadata.yaml"):
+            self.process_metadata(path)
 
     def process_metadata(self, path: Path) -> "DocGen":
         if path in self._loaded:

--- a/aws_doc_sdk_examples_tools/test_resources/doc_gen_tributary_test/.doc_gen/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/doc_gen_tributary_test/.doc_gen/config/sdks.yaml
@@ -1,0 +1,13 @@
+IAMPolicy:
+  property: json
+  syntax: json
+  sdk:
+    1:
+      long: "IAM policy"
+      short: "IAM policy"
+      guide: "IAM/latest/UserGuide/introduction.html"
+      api_ref:
+        uid: "IAMPolicy"
+        name: "&SAZR;"
+        link_template: "SomeTemplate"
+  guide: "&guide-iam-user;"

--- a/aws_doc_sdk_examples_tools/test_resources/doc_gen_tributary_test/.doc_gen/metadata/example_with_custom_sdk_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/doc_gen_tributary_test/.doc_gen/metadata/example_with_custom_sdk_metadata.yaml
@@ -1,0 +1,13 @@
+sts_CustomSdkExample:
+  title: This example uses an SDK from the tributary config
+  title_abbrev: This example uses an SDK from the tributary config
+  synopsis: allow a user to assume any role in your account with the access- name prefix. The role must also be tagged with the same project, team, and cost center tags as the user.
+  category: IAMPolicyCategory
+  languages:
+    IAMPolicy:
+      versions:
+        - sdk_version: 1
+          excerpts:
+            - description: test
+  services:
+    sts: {AssumeRole}

--- a/aws_doc_sdk_examples_tools/test_resources/doc_gen_tributary_test/.doc_gen/metadata/example_with_root_sdk_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/doc_gen_tributary_test/.doc_gen/metadata/example_with_root_sdk_metadata.yaml
@@ -1,0 +1,13 @@
+sts_RootSdkExample:
+  title: This example uses an SDK from the root config
+  title_abbrev: This example uses an SDK from the root config
+  synopsis: allow a user to assume any role in your account with the access- name prefix. The role must also be tagged with the same project, team, and cost center tags as the user.
+  category: IAMPolicyCategory
+  languages:
+    Python:
+      versions:
+        - sdk_version: 3
+          excerpts:
+            - description: test
+  services:
+    sts: {AssumeRole}

--- a/aws_doc_sdk_examples_tools/validate_test.py
+++ b/aws_doc_sdk_examples_tools/validate_test.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for validate.
+"""
+
+from pathlib import Path
+
+from .validate import validate
+
+
+def test_validate():
+    root_path = Path(__file__).parent / "test_resources" / "doc_gen_tributary_test"
+    error_count = validate(root_path, root_path / ".doc_gen/config", False, False)
+    assert error_count == 0


### PR DESCRIPTION
Tributaries must validate using strictly the root config + their own config. The current order is to:

1. Load the root config.
2. Load the tributary config + examples all at once.
3. Merge the tributary onto the root config.
4. Validate.

Because of this, the DocGen used for loading examples in step 2 did not have the services and SDKs merged and, when the examples are loaded, preliminary validation is performed (checking that the language in the example exists in the SDK list) and fails.

This PR updates the order for tributary validation to be:

1. Load root config.
2. Load and merge tributary config.
3. Load and merge tributary examples.
4. Validate.

In this way, at step 3 the DocGen has all of the merged config it needs and the examples pass the preliminary checks.

**Testing**

I refactored slightly to help write a unit test that can call validate to test the whole process instead of unit tests in isolation, and added a test to simulate validating a tributary with a custom SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
