### PR TITLE
Add fields to sdk and category to let authors control display.

### DIFF
--- a/aws_doc_sdk_examples_tools/categories.py
+++ b/aws_doc_sdk_examples_tools/categories.py
@@ -57,6 +57,25 @@ class TitleInfo:
 
 
 @dataclass
+class Prefix:
+    one: Optional[str]
+    many: Optional[str]
+
+    @classmethod
+    def from_yaml(cls, yaml: Optional[Dict[str, str]]) -> Optional[Prefix]:
+        if yaml is None:
+            return None
+
+        one = yaml.get("one")
+        many = yaml.get("many")
+
+        return cls(
+            one=one,
+            many=many,
+        )
+
+
+@dataclass
 class CategoryWithNoDisplayError(metadata_errors.MetadataError):
     def message(self):
         return "Category has no display value"
@@ -72,6 +91,8 @@ class Category:
     defaults: Optional[TitleInfo] = field(default=None)
     overrides: Optional[TitleInfo] = field(default=None)
     description: Optional[str] = field(default=None)
+    synopsis_prefix: Optional[Prefix] = field(default=None)
+    more_info: Optional[str] = field(default=None)
 
     def evaluate(
         self,
@@ -103,6 +124,8 @@ class Category:
         defaults = TitleInfo.from_yaml(yaml.get("defaults"))
         overrides = TitleInfo.from_yaml(yaml.get("overrides"))
         description = yaml.get("description")
+        synopsis_prefix = Prefix.from_yaml(yaml.get("synopsis_prefix"))
+        more_info = yaml.get("more_info")
 
         return (
             cls(
@@ -111,6 +134,8 @@ class Category:
                 defaults=defaults,
                 overrides=overrides,
                 description=description,
+                synopsis_prefix=synopsis_prefix,
+                more_info=more_info,
             ),
             errors,
         )

--- a/aws_doc_sdk_examples_tools/categories_test.py
+++ b/aws_doc_sdk_examples_tools/categories_test.py
@@ -11,6 +11,7 @@ from .categories import (
     parse,
     Category,
     TitleInfo,
+    Prefix,
 )
 
 
@@ -65,6 +66,8 @@ def test_categories():
             key="TributaryLite",
             display="Tea light",
             description="light your way.",
+            synopsis_prefix=Prefix(one="Tea light is", many="Tea lights are"),
+            more_info="This is more tea light info.",
         ),
     }
 

--- a/aws_doc_sdk_examples_tools/config/sdks_schema.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks_schema.yaml
@@ -3,10 +3,12 @@
 map(include('sdk'), key=enum('Bash', 'C++', 'CLI', 'Go', 'Java', 'JavaScript', 'Kotlin', '.NET', 'PHP', 'PowerShell', 'Python', 'Ruby', 'Rust', 'SAP ABAP', 'Swift'))
 ---
 sdk:
+  display: str(required=False)
   property: include('syntax_enum')
   syntax: include('syntax_enum', required=False)
   sdk: map(include('version'), key=int(min=1))
   guide: include('entity_regex')
+  is_pseudo_sdk: bool(required=False)
 
 version:
   long: include('entity_with_version_regex')
@@ -14,6 +16,7 @@ version:
   expanded:
     long: str(upper_start=True, end_punc=False, check_aws=False)
     short: str(upper_start=True, end_punc=False, check_aws=False)
+  suppress_version_heading: bool(required=False)
   guide: str()
   caveat: str(required=False, upper_start=True, end_punc=True)
   bookmark: str(required=False)

--- a/aws_doc_sdk_examples_tools/doc_gen_cli_test.py
+++ b/aws_doc_sdk_examples_tools/doc_gen_cli_test.py
@@ -60,9 +60,11 @@ def mock_doc_gen(mock_example):
     doc_gen.sdks = {
         "JavaScript": Sdk(
             name="JavaScript",
+            display="JavaScript",
             versions=[SdkVersion(version=3, long="&JS;", short="&JSlong")],
             guide="",
             property="javascript",
+            is_pseudo_sdk=False,
         )
     }
     doc_gen.examples = {"ex": mock_example}

--- a/aws_doc_sdk_examples_tools/doc_gen_test.py
+++ b/aws_doc_sdk_examples_tools/doc_gen_test.py
@@ -26,7 +26,14 @@ from .snippets import Snippet
                 root=Path("/a"),
                 errors=MetadataErrors(),
                 sdks={
-                    "a": Sdk(name="a", guide="guide_a", property="a_prop", versions=[])
+                    "a": Sdk(
+                        name="a",
+                        display="aa",
+                        guide="guide_a",
+                        property="a_prop",
+                        versions=[],
+                        is_pseudo_sdk=False,
+                    ),
                 },
                 services={
                     "x": Service(long="AWS X", short="X", sort="aws x", version=1)
@@ -36,7 +43,14 @@ from .snippets import Snippet
                 root=Path("/b"),
                 errors=MetadataErrors(),
                 sdks={
-                    "b": Sdk(name="b", guide="guide_b", property="b_prop", versions=[])
+                    "b": Sdk(
+                        name="b",
+                        display="bb",
+                        guide="guide_b",
+                        property="b_prop",
+                        versions=[],
+                        is_pseudo_sdk=False,
+                    ),
                 },
                 services={
                     "y": Service(long="AWS Y", short="Y", sort="aws y", version=1)
@@ -46,8 +60,22 @@ from .snippets import Snippet
                 root=Path("/a"),
                 errors=MetadataErrors(),
                 sdks={
-                    "a": Sdk(name="a", guide="guide_a", property="a_prop", versions=[]),
-                    "b": Sdk(name="b", guide="guide_b", property="b_prop", versions=[]),
+                    "a": Sdk(
+                        name="a",
+                        display="aa",
+                        guide="guide_a",
+                        property="a_prop",
+                        versions=[],
+                        is_pseudo_sdk=False,
+                    ),
+                    "b": Sdk(
+                        name="b",
+                        display="bb",
+                        guide="guide_b",
+                        property="b_prop",
+                        versions=[],
+                        is_pseudo_sdk=False,
+                    ),
                 },
                 services={
                     "x": Service(long="AWS X", short="X", sort="aws x", version=1),
@@ -91,9 +119,11 @@ def sample_doc_gen() -> DocGen:
         sdks={
             "python": Sdk(
                 name="python",
+                display="Python",
                 versions=[SdkVersion(version=1, long="&PYLong;", short="&PYShort;")],
                 guide="Python Guide",
                 property="python",
+                is_pseudo_sdk=False,
             )
         },
         services={
@@ -167,7 +197,9 @@ def test_doc_gen_encoder(sample_doc_gen: DocGen):
     assert "sdks" in decoded
     assert "python" in decoded["sdks"]
     assert decoded["sdks"]["python"]["name"] == "python"
+    assert decoded["sdks"]["python"]["display"] == "Python"
     assert decoded["sdks"]["python"]["guide"] == "Python Guide"
+    assert decoded["sdks"]["python"]["is_pseudo_sdk"] == False
     assert decoded["sdks"]["python"]["versions"][0]["version"] == 1
     assert decoded["sdks"]["python"]["versions"][0]["long"] == "&PYLong;"
 

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -89,10 +89,38 @@ SERVICES = {
     ),
 }
 SDKS = {
-    "C++": Sdk(name="C++", versions=[], guide="", property="cpp"),
-    "Java": Sdk(name="Java", versions=[], guide="", property="java"),
-    "JavaScript": Sdk(name="JavaScript", versions=[], guide="", property="javascript"),
-    "PHP": Sdk(name="PHP", versions=[], guide="", property="php"),
+    "C++": Sdk(
+        name="C++",
+        display="C++",
+        versions=[],
+        guide="",
+        property="cpp",
+        is_pseudo_sdk=False,
+    ),
+    "Java": Sdk(
+        name="Java",
+        display="Java",
+        versions=[],
+        guide="",
+        property="java",
+        is_pseudo_sdk=False,
+    ),
+    "JavaScript": Sdk(
+        name="JavaScript",
+        display="JavaScript",
+        versions=[],
+        guide="",
+        property="javascript",
+        is_pseudo_sdk=False,
+    ),
+    "PHP": Sdk(
+        name="PHP",
+        display="PHP",
+        versions=[],
+        guide="",
+        property="php",
+        is_pseudo_sdk=False,
+    ),
 }
 STANDARD_CATS = ["Api"]
 DOC_GEN = DocGen(

--- a/aws_doc_sdk_examples_tools/sdks_test.py
+++ b/aws_doc_sdk_examples_tools/sdks_test.py
@@ -73,8 +73,10 @@ def test_sdks():
     expected = {
         "C++": Sdk(
             name="C++",
+            display="C++",
             property="cpp",
             guide="&guide-cpp-dev;",
+            is_pseudo_sdk=False,
             versions=[
                 SdkVersion(
                     version=1, long="&CPPlong;", short="&CPP;", bookmark="code-examples"
@@ -83,8 +85,10 @@ def test_sdks():
         ),
         "Go": Sdk(
             name="Go",
+            display="Go",
             property="go",
             guide="&guide-go-dev;",
+            is_pseudo_sdk=False,
             versions=[
                 SdkVersion(version=1, long="&Golong; V1", short="&Go; V1"),
                 SdkVersion(version=2, long="&Golong; V2", short="&Go; V2"),
@@ -92,8 +96,10 @@ def test_sdks():
         ),
         "Java": Sdk(
             name="Java",
+            display="Java",
             property="java",
             guide="&guide-javav2-dev;",
+            is_pseudo_sdk=False,
             versions=[
                 SdkVersion(version=1, long="&Javalong;", short="&Java;"),
                 SdkVersion(version=2, long="&JavaV2long;", short="&Java;"),
@@ -101,8 +107,10 @@ def test_sdks():
         ),
         "JavaScript": Sdk(
             name="JavaScript",
+            display="JavaScript",
             property="javascript",
             guide="&guide-jsb-dev;",
+            is_pseudo_sdk=False,
             versions=[
                 SdkVersion(version=2, long="&JSBlong; V2", short="&JSB; V2"),
                 SdkVersion(
@@ -119,8 +127,10 @@ def test_sdks():
         ),
         "Kotlin": Sdk(
             name="Kotlin",
+            display="Kotlin",
             property="kotlin",
             guide="&NO_GUIDE;",
+            is_pseudo_sdk=False,
             versions=[
                 SdkVersion(
                     version=1,
@@ -132,8 +142,10 @@ def test_sdks():
         ),
         ".NET": Sdk(
             name=".NET",
+            display=".NET",
             property="csharp",
             guide="&guide-net-dev;",
+            is_pseudo_sdk=False,
             versions=[
                 SdkVersion(
                     version=3,
@@ -148,20 +160,26 @@ def test_sdks():
         ),
         "PHP": Sdk(
             name="PHP",
+            display="PHP",
             property="php",
             guide="&guide-php-dev;",
+            is_pseudo_sdk=False,
             versions=[SdkVersion(version=3, long="&PHPlong;", short="&PHP;")],
         ),
         "Python": Sdk(
             name="Python",
+            display="Python",
             property="python",
             guide="&guide-python3-gsg;",
+            is_pseudo_sdk=False,
             versions=[SdkVersion(version=3, long="&Python3long;", short="&Python3;")],
         ),
         "Ruby": Sdk(
             name="Ruby",
+            display="Ruby",
             property="ruby",
             guide="&guide-ruby-dev;",
+            is_pseudo_sdk=False,
             versions=[SdkVersion(version=3, long="&Rubylong;", short="&Ruby;")],
         ),
     }
@@ -173,13 +191,16 @@ def test_pseudo_sdks():
     expected = {
         "IAMPolicy": Sdk(
             name="IAMPolicy",
+            display="IAM policy grammar",
             property="policy",
             guide="&guide-iam-user;",
+            is_pseudo_sdk=True,
             versions=[
                 SdkVersion(
                     version=1,
                     long="IAM policy long",
                     short="IAM policy short",
+                    suppress_version_heading=True,
                     guide="IAM/latest/UserGuide/introduction.html",
                     api_ref=SdkApiRef(
                         uid="IAMPolicy",

--- a/aws_doc_sdk_examples_tools/test_resources/categories.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/categories.yaml
@@ -19,3 +19,7 @@ categories:
   TributaryLite:
     display: "Tea light"
     description: "light your way."
+    synopsis_prefix:
+      one: "Tea light is"
+      many: "Tea lights are"
+    more_info: "This is more tea light info."

--- a/aws_doc_sdk_examples_tools/test_resources/pseudo_sdks.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/pseudo_sdks.yaml
@@ -1,9 +1,12 @@
 IAMPolicy:
+  display: "IAM policy grammar"
   property: policy
+  is_pseudo_sdk: true
   sdk:
     1:
       long: "IAM policy long"
       short: "IAM policy short"
+      suppress_version_heading: true
       guide: "IAM/latest/UserGuide/introduction.html"
       api_ref:
         uid: "IAMPolicy"


### PR DESCRIPTION
Add SDK and Category fields used by the publishing frontend to allow for customization of the display:

- `sdk.display` defines a string to display instead of the SDK key value so that a longer display string can be defined that's separate from the key.
- `sdk.is_pseudo_sdk` indicates whether the SDK is a true AWS SDK or something else. When true, the pseudo SDK is not included in the Code Library "by SDK" chapter.
- `sdk.version.suppress_version_heading` when true, suppresses the SDK version heading inside the tablist.
- `category.synopsis_prefix` defines strings for the synopsis prefix instead of the default "This code example shows how to".
- `category.more_info` defines a string that is used at the bottom of an example beneath the tablist that direct the reader to more information about the specific category of example.

These fields have already been incorporated into the backend ZonBook processor.

**Testing**

* Unit tests
* Root repo validation
* Internal builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
