### PR TITLE
Added author and owner fields at the example version level.

### DIFF
--- a/aws_doc_sdk_examples_tools/metadata.py
+++ b/aws_doc_sdk_examples_tools/metadata.py
@@ -28,6 +28,19 @@ class Url:
 
 
 @dataclass
+class Person:
+    name: str
+    alias: str
+
+
+@dataclass
+class FeedbackCti:
+    category: str
+    type: str
+    item: str
+
+
+@dataclass
 class Excerpt:
     description: Optional[str]
     # Tags embedded in source files to extract as snippets.
@@ -59,6 +72,10 @@ class Version:
     sdkguide: Optional[str] = field(default=None)
     # Link to additional topic places.
     more_info: List[Url] = field(default_factory=list)
+    # List of people who have contributed to this example.
+    authors: List[Person] = field(default_factory=list)
+    # Feedback and maintenance owner. Primarily for internal use.
+    owner: Optional[FeedbackCti] = field(default=None)
 
     def validate(self, errors: MetadataErrors, root: Path):
         github = self.github

--- a/aws_doc_sdk_examples_tools/metadata_errors.py
+++ b/aws_doc_sdk_examples_tools/metadata_errors.py
@@ -242,6 +242,16 @@ class InvalidSdkVersion(SdkVersionError):
 
 
 @dataclass
+class InvalidFeedbackCti(SdkVersionError):
+    feedback_cti: str = ""
+
+    def message(self):
+        return (
+            f"has feedback CTI that is missing at least one field: {self.feedback_cti}"
+        )
+
+
+@dataclass
 class InvalidGithubLink(SdkVersionError):
     link: str = ""
 
@@ -368,6 +378,15 @@ class URLMissingTitle(SdkVersionError):
 
     def message(self):
         return f"URL {self.url} is missing a title"
+
+
+@dataclass
+class PersonMissingField(SdkVersionError):
+    name: str = ""
+    alias: str = ""
+
+    def message(self):
+        return f"person is missing a field: name: {self.name}, alias: {self.alias}"
 
 
 @dataclass

--- a/aws_doc_sdk_examples_tools/metadata_test.py
+++ b/aws_doc_sdk_examples_tools/metadata_test.py
@@ -741,6 +741,21 @@ FORMATTER_METADATA_PATH = TEST_RESOURCES_PATH / "formaterror_metadata.yaml"
                     file=ERRORS_METADATA_PATH,
                     id="medical-imagingBadFormat",
                 ),
+                metadata_errors.PersonMissingField(
+                    file=ERRORS_METADATA_PATH,
+                    id="sqs_InvalidOwner",
+                    language="Java",
+                    sdk_version=2,
+                    name="None",
+                    alias="author@example.com",
+                ),
+                metadata_errors.InvalidFeedbackCti(
+                    file=ERRORS_METADATA_PATH,
+                    id="sqs_InvalidOwner",
+                    language="Java",
+                    sdk_version=2,
+                    feedback_cti="AWS|Documentation|None",
+                ),
             ],
             [
                 metadata_errors.MissingGithubLink(

--- a/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
+++ b/aws_doc_sdk_examples_tools/test_resources/errors_metadata.yaml
@@ -96,3 +96,22 @@ medical-imagingBadFormat:
         - sdk_version: 2
   services:
     medical-imaging: { TestAction }
+sqs_InvalidOwner:
+  title: Invalid owner
+  title_abbrev: Invalid owner abbrev
+  synopsis: This synopsis is just fine.
+  category: Test
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          authors:
+            - alias: author@example.com
+          owner:
+            category: AWS
+            type: Documentation
+          excerpts:
+            - snippet_tags:
+                - invalid.feedback.cti
+  services:
+    sqs:


### PR DESCRIPTION
* `authors` is a list of people who created the example.
* `owner` is data that can be be used to submit feedback and maintenance requests (primarily for internal use).

These fields are optional and will frequently be empty in individual examples. When empty, the values default to the author and owner configured for each tributary.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
