### PR TITLE
Adding .NET v4 to SDK definitions

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -230,6 +230,16 @@ Kotlin:
       api_ref:
         uid: "DotNetSDKV3"
         name: "&guide-net-api;"
+    4:
+      long: "&NETlong;"
+      short: "&NET;"
+      expanded:
+        long: "AWS SDK for .NET"
+        short: "SDK for .NET"
+      guide: "sdk-for-net/v3/developer-guide/welcome.html"
+      api_ref:
+        uid: "DotNetSDKV3"
+        name: "&guide-net-api;"
   guide: "&guide-net-dev;"
 PHP:
   property: php

--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -236,7 +236,7 @@ Kotlin:
       expanded:
         long: "AWS SDK for .NET (v4)"
         short: "SDK for .NET (v4)"
-      guide: "sdk-for-net/v3/developer-guide/welcome.html"
+      guide: "sdk-for-net/v4/developer-guide/welcome.html"
       api_ref:
         uid: "DotNetSDKV4"
         name: "&guide-net-api;"

--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -231,15 +231,12 @@ Kotlin:
         uid: "DotNetSDKV3"
         name: "&guide-net-api;"
     4:
-      long: "&NETlong;"
-      short: "&NET;"
+      long: "&NETlong; (v4)"
+      short: "&NET; (v4)"
       expanded:
-        long: "AWS SDK for .NET"
-        short: "SDK for .NET"
+        long: "AWS SDK for .NET (v4)"
+        short: "SDK for .NET (v4)"
       guide: "sdk-for-net/v3/developer-guide/welcome.html"
-      api_ref:
-        uid: "DotNetSDKV3"
-        name: "&guide-net-api;"
   guide: "&guide-net-dev;"
 PHP:
   property: php

--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -237,6 +237,9 @@ Kotlin:
         long: "AWS SDK for .NET (v4)"
         short: "SDK for .NET (v4)"
       guide: "sdk-for-net/v3/developer-guide/welcome.html"
+      api_ref:
+        uid: "DotNetSDKV4"
+        name: "&guide-net-api;"
   guide: "&guide-net-dev;"
 PHP:
   property: php


### PR DESCRIPTION
This PR adds .NET v4 to SDK definitions, so we can add v4 examples to the code library.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
