### PR TITLE
Remove yamale check to validate example service

### DIFF
--- a/aws_doc_sdk_examples_tools/config/example_schema.yaml
+++ b/aws_doc_sdk_examples_tools/config/example_schema.yaml
@@ -12,7 +12,7 @@ example:
   guide_topic: include('guide_topic', required=False)
   languages: map(include('language'))
   service_main: service_name(required=False)
-  services: map(key=service_name())
+  services: map(key=str())
 
 guide_topic:
   title: str(upper_start=True, no_end_punc=True)

--- a/aws_doc_sdk_examples_tools/config/example_strict_schema.yaml
+++ b/aws_doc_sdk_examples_tools/config/example_strict_schema.yaml
@@ -12,7 +12,7 @@ example:
   guide_topic: include('guide_topic', required=False)
   languages: map(include('language'))
   service_main: service_name(required=False)
-  services: map(map(key=str(), required=False), key=service_name())
+  services: map(map(key=str(), required=False), key=str())
 
 guide_topic:
   title: str(upper_start=True, no_end_punc=True)


### PR DESCRIPTION
The yamale schema validator currently validates that services listed in examples are contained in the `services.yaml`. This doesn't work for tributary-defined services because the tributary `services.yaml` file isn't loaded for yamale check.

However, this check is also already being done in code when examples are further validated beyond the yamale checks, and at that time the full services list has been loaded and merged so validation works as expected.

This update removes the redundant and overly rigid yamale checks.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
