### PR TITLE
Update sdks.yaml to add Go mapping value for Partner Central Selling

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -108,6 +108,7 @@ Go:
           mediastore-data: mediastoredata
           medical-imaging: medicalimaging
           migration-hub: migrationhub
+          partnercentral-selling: partnercentralselling
           payment-cryptography: paymentcryptography
           payment-cryptography-data: paymentcryptographydata
           personalize-runtime: personalizeruntime


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a line to sdks.yaml to map `partnercentral-selling` to `parnercentralselling` for the GoV2 SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
