### PR TITLE
Abstract filesystem operations in snippets.py

### DIFF
--- a/aws_doc_sdk_examples_tools/fs.py
+++ b/aws_doc_sdk_examples_tools/fs.py
@@ -57,11 +57,11 @@ class PathFs(Fs):
             return file.read()
 
     def readlines(self, path: Path) -> List[str]:
-        with path.open("r") as file:
+        with path.open("r", encoding="utf-8") as file:
             return file.readlines()
 
     def write(self, path: Path, content: str):
-        with path.open("w") as file:
+        with path.open("w", encoding="utf-8") as file:
             file.write(content)
 
     def stat(self, path: Path) -> Stat:

--- a/aws_doc_sdk_examples_tools/fs.py
+++ b/aws_doc_sdk_examples_tools/fs.py
@@ -28,7 +28,7 @@ class Fs(ABC):
         pass
 
     @abstractmethod
-    def readlines(self, path: Path) -> List[str]:
+    def readlines(self, path: Path, encoding: str = "utf-8") -> List[str]:
         pass
 
     @abstractmethod
@@ -56,8 +56,8 @@ class PathFs(Fs):
         with path.open("r", encoding="utf-8") as file:
             return file.read()
 
-    def readlines(self, path: Path) -> List[str]:
-        with path.open("r", encoding="utf-8") as file:
+    def readlines(self, path: Path, encoding: str = "utf-8") -> List[str]:
+        with path.open("r", encoding=encoding) as file:
             return file.readlines()
 
     def write(self, path: Path, content: str):
@@ -95,7 +95,7 @@ class RecordFs(Fs):
     def read(self, path: Path) -> str:
         return self.fs[path]
 
-    def readlines(self, path: Path) -> List[str]:
+    def readlines(self, path: Path, encoding: str = "utf-8") -> List[str]:
         content = self.fs[path]
         return content.splitlines(keepends=True)
 

--- a/aws_doc_sdk_examples_tools/snippets_test.py
+++ b/aws_doc_sdk_examples_tools/snippets_test.py
@@ -5,6 +5,9 @@ import pytest
 from pathlib import Path
 
 from aws_doc_sdk_examples_tools import snippets
+from aws_doc_sdk_examples_tools.fs import RecordFs
+from aws_doc_sdk_examples_tools.metadata import Example, Language, Version, Excerpt
+from aws_doc_sdk_examples_tools.metadata_errors import MetadataErrors
 
 
 @pytest.mark.parametrize(
@@ -102,3 +105,159 @@ def test_strip_spdx_header():
     )
 
     assert [] == snippets.strip_spdx_header([])
+
+
+class TestFindSnippetsFs:
+    """Test find_snippets with filesystem abstraction."""
+
+    def test_find_snippets_with_recordfs(self):
+        """Test find_snippets using RecordFs."""
+        fs = RecordFs(
+            {
+                Path(
+                    "/project/test.py"
+                ): """# snippet-start:[example.hello]
+def hello():
+    print("Hello, World!")
+# snippet-end:[example.hello]
+"""
+            }
+        )
+
+        snippet_dict, errors = snippets.find_snippets(
+            Path("/project/test.py"), "", fs=fs
+        )
+
+        assert len(errors) == 0
+        assert len(snippet_dict) == 1
+        assert "example.hello" in snippet_dict
+        snippet = snippet_dict["example.hello"]
+        assert snippet.id == "example.hello"
+        assert "def hello():" in snippet.code
+
+    def test_find_snippets_missing_file_graceful(self):
+        """Test find_snippets behavior with missing files."""
+        fs = RecordFs({})
+
+        snippet_dict, errors = snippets.find_snippets(
+            Path("/project/missing.py"), "", fs=fs
+        )
+
+        # Missing files generate errors (not handled gracefully)
+        assert len(snippet_dict) == 0
+        assert len(errors) == 1  # Should have a FileReadError
+
+
+class TestCollectSnippetsFs:
+    """Test collect_snippets with filesystem abstraction."""
+
+    def test_collect_snippets_with_recordfs(self):
+        """Test collect_snippets using RecordFs."""
+        fs = RecordFs(
+            {
+                Path(
+                    "/project/src/file1.py"
+                ): """# snippet-start:[example1]
+def example1():
+    pass
+# snippet-end:[example1]
+""",
+                Path(
+                    "/project/src/file2.py"
+                ): """# snippet-start:[example2]
+def example2():
+    pass
+# snippet-end:[example2]
+""",
+            }
+        )
+
+        snippet_dict, errors = snippets.collect_snippets(Path("/project/src"), fs=fs)
+
+        assert len(errors) == 0
+        assert len(snippet_dict) == 2
+        assert "example1" in snippet_dict
+        assert "example2" in snippet_dict
+
+
+class TestCollectSnippetFilesFs:
+    """Test collect_snippet_files with filesystem abstraction."""
+
+    def test_collect_snippet_files_with_recordfs(self):
+        """Test collect_snippet_files using RecordFs."""
+        fs = RecordFs({Path("/project/example.py"): "print('Hello, World!')\n"})
+
+        example = Example(
+            id="test_example",
+            file=None,
+            languages={
+                "python": Language(
+                    name="python",
+                    property="python",
+                    versions=[
+                        Version(
+                            sdk_version="3",
+                            excerpts=[
+                                Excerpt(
+                                    description="Test excerpt",
+                                    snippet_tags=[],
+                                    snippet_files=["example.py"],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            },
+        )
+
+        snippet_dict = {}
+        errors = MetadataErrors()
+
+        snippets.collect_snippet_files(
+            [example], snippet_dict, "", errors, Path("/project"), fs=fs
+        )
+
+        assert len(errors) == 0
+        assert len(snippet_dict) == 1
+        assert "example.py" in snippet_dict
+        snippet = snippet_dict["example.py"]
+        assert snippet.file == "example.py"
+        assert "Hello, World!" in snippet.code
+
+    def test_collect_snippet_files_missing_file_error(self):
+        """Test collect_snippet_files properly reports missing files as errors."""
+        fs = RecordFs({})  # Empty filesystem
+
+        example = Example(
+            id="test_example",
+            file=None,
+            languages={
+                "python": Language(
+                    name="python",
+                    property="python",
+                    versions=[
+                        Version(
+                            sdk_version="3",
+                            excerpts=[
+                                Excerpt(
+                                    description="Test excerpt",
+                                    snippet_tags=[],
+                                    snippet_files=["missing.py"],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            },
+        )
+
+        snippet_dict = {}
+        errors = MetadataErrors()
+
+        snippets.collect_snippet_files(
+            [example], snippet_dict, "", errors, Path("/project"), fs=fs
+        )
+
+        # Missing snippet files should generate errors (unlike find_snippets)
+        assert len(errors) == 1
+        assert len(snippet_dict) == 0


### PR DESCRIPTION
This PR builds on #179 and abstracts filesystem operations in snippets.py.

## Changes
- Add `fs: Fs` parameter to `collect_snippets`, `find_snippets`, and `collect_snippet_files` functions
- Replace direct filesystem calls with Fs interface methods:
  - Use `fs.readlines()` instead of `open().readlines()`
  - Use `fs.stat()` instead of `path.exists()`
- Fix `PathFs` to use UTF-8 encoding for all file operations (`read`, `readlines`, `write`)
- Add comprehensive tests using RecordFs for deterministic testing

## Testing
- All existing tests continue to pass
- New tests cover snippet collection, file handling, and error cases
- Tests use RecordFs for fast, deterministic filesystem simulation
- Tests properly handle missing files and validate error reporting

## Dependencies
- Depends on PR #179 (file_utils.py abstraction)
- Depends on PR #178 (Fs interface with readlines method)