### PR TITLE
Add option to turn off non-entity AWS usage

### DIFF
--- a/aws_doc_sdk_examples_tools/lliam/service_layer/dedupe_reservoir.py
+++ b/aws_doc_sdk_examples_tools/lliam/service_layer/dedupe_reservoir.py
@@ -7,6 +7,7 @@ from aws_doc_sdk_examples_tools.doc_gen import DocGen
 from aws_doc_sdk_examples_tools.lliam.domain.commands import DedupeReservoir
 from aws_doc_sdk_examples_tools.metadata import Example
 from aws_doc_sdk_examples_tools.yaml_writer import prepare_write, write_many
+from aws_doc_sdk_examples_tools.project_validator import ValidationConfig
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def make_title_abbreviation(example: Example, counter: Counter):
 
 
 def handle_dedupe_reservoir(cmd: DedupeReservoir, uow: None):
-    doc_gen = DocGen.from_root(cmd.root)
+    doc_gen = DocGen.from_root(cmd.root, validation=ValidationConfig(check_aws=False))
 
     examples: Dict[str, Example] = {}
 

--- a/aws_doc_sdk_examples_tools/lliam/service_layer/run_ailly.py
+++ b/aws_doc_sdk_examples_tools/lliam/service_layer/run_ailly.py
@@ -115,7 +115,7 @@ def run_ailly_single_batch(batch: Path, packages: List[str] = []) -> None:
     )
 
 
-EXPECTED_KEYS: Set[str] = set(["title", "title_abbrev"])
+EXPECTED_KEYS: Set[str] = set(["title", "title_abbrev", "synopsis"])
 VALUE_PREFIXES: Dict[str, str] = {"title": "", "title_abbrev": "", "synopsis": ""}
 
 

--- a/aws_doc_sdk_examples_tools/project_validator.py
+++ b/aws_doc_sdk_examples_tools/project_validator.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ValidationConfig:
     allow_list: Set[str] = field(default_factory=set)
+    check_aws: bool = True
     sample_files: Set[Path] = field(default_factory=set)
     strict_titles: bool = False
 

--- a/aws_doc_sdk_examples_tools/yaml_mapper.py
+++ b/aws_doc_sdk_examples_tools/yaml_mapper.py
@@ -30,9 +30,27 @@ def example_from_yaml(
 ) -> Tuple[Example, MetadataErrors]:
     errors = MetadataErrors()
 
-    title = get_with_valid_entities("title", yaml, errors, True)
-    title_abbrev = get_with_valid_entities("title_abbrev", yaml, errors, True)
-    synopsis = get_with_valid_entities("synopsis", yaml, errors, opt=True)
+    title = get_field(
+        name="title",
+        d=yaml,
+        errors=errors,
+        opt=True,
+        check_aws=validation.check_aws,
+    )
+    title_abbrev = get_field(
+        name="title_abbrev",
+        d=yaml,
+        errors=errors,
+        opt=True,
+        check_aws=validation.check_aws,
+    )
+    synopsis = get_field(
+        name="synopsis",
+        d=yaml,
+        errors=errors,
+        opt=True,
+        check_aws=validation.check_aws,
+    )
     synopsis_list = [str(syn) for syn in yaml.get("synopsis_list", [])]
 
     source_key = yaml.get("source_key")
@@ -123,8 +141,12 @@ def excerpt_from_yaml(yaml: Any) -> Tuple["Excerpt", MetadataErrors]:
     return (Excerpt(description, snippet_tags, snippet_files, genai), errors)
 
 
-def get_with_valid_entities(
-    name: str, d: Dict[str, str], errors: MetadataErrors, opt: bool = False
+def get_field(
+    name: str,
+    d: Dict[str, str],
+    errors: MetadataErrors,
+    opt: bool = False,
+    check_aws=True,
 ) -> str:
     field = d.get(name)
     if field is None:
@@ -132,7 +154,7 @@ def get_with_valid_entities(
             errors.append(metadata_errors.MissingField(field=name))
         return ""
 
-    checker = StringExtension()
+    checker = StringExtension(check_aws=check_aws)
     if not checker.is_valid(field):
         errors.append(
             metadata_errors.AwsNotEntity(
@@ -195,7 +217,7 @@ def parse_services(yaml: Any, errors: MetadataErrors) -> Dict[str, Set[str]]:
 
 
 def url_from_yaml(
-    yaml: Union[None, Dict[str, Optional[str]]]
+    yaml: Union[None, Dict[str, Optional[str]]],
 ) -> Optional[Union[Url, MetadataParseError]]:
     if yaml is None:
         return None
@@ -209,7 +231,7 @@ def url_from_yaml(
 
 
 def person_from_yaml(
-    yaml: Union[None, Dict[str, Optional[str]]]
+    yaml: Union[None, Dict[str, Optional[str]]],
 ) -> Optional[Union[Person, MetadataParseError]]:
     if yaml is None:
         return None


### PR DESCRIPTION
Lliam, because it writes out LLM generated content without entities, and uses DocGen to read the metadata back, needed this option.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
