### PR TITLE
Python v4 updates

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -286,16 +286,16 @@ Python:
   property: python
   sdk:
     1:
-      long: "&Python1long;"
-      short: "&Python1;"
+      long: "&Python4long;"
+      short: "&Python4;"
       expanded:
-        long: "AWS SDK for Python"
-        short: "SDK for Python"
-      guide: "https://docs.aws.amazon.com/sdk-for-python/v1/guide/index.html"
+        long: "AWS SDK for Python v4"
+        short: "SDK for Python v4"
+      guide: "https://docs.aws.amazon.com/sdk-for-python/v4/guide/index.html"
       api_ref:
-        uid: "pythonv1"
-        name: "&guide-python1-api;"
-        link_template: "https://docs.aws.amazon.com/sdk-for-python/v1/reference/index.html"
+        uid: "pythonv4"
+        name: "&guide-python4-api;"
+        link_template: "https://docs.aws.amazon.com/sdk-for-python/v4/reference/index.html"
     3:
       long: "&Python3long;"
       short: "&Python3;"

--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -285,7 +285,7 @@ PowerShell:
 Python:
   property: python
   sdk:
-    1:
+    4:
       long: "&Python4long;"
       short: "&Python4;"
       expanded:


### PR DESCRIPTION
Migrate the Python SDK configuration in sdks.yaml from v1 to v4. AWS SDK for Python v1 reached
  end-of-support, so this removes it from the SDK version metadata and registers v4 as a
  first-class version alongside v3.

**Note for reviewer**:
- This PR is in draft as Python team has to align prior to this being published. The Python team are doing a brand switch from v1 to v4. I will move this from draft once they've agreed on these specific changes
- Additional steps are required to push these changes once merged to the the released version of aws-doc-sdk-examples-tools (see [New Releases](https://github.com/awsdocs/aws-doc-sdk-examples-tools#2-deployment))
  
 **Changes**
  
  - Drop the Python v1 SDK entry entirely and replace it with v4 in
  aws_doc_sdk_examples_tools/config/sdks.yaml:
    - SDK version key changed from 1 to 4
    - Entity refs updated: &Python1long;/&Python1; → &Python4long;/&Python4;
    - Expanded names: "AWS SDK for Python" → "AWS SDK for Python v4"
    - Guide URL: .../sdk-for-python/v1/guide/... → .../v4/guide/...
    - API ref: uid: pythonv1 → pythonv4, name &guide-python1-api; → &guide-python4-api;, reference
  link v1 → v4
  
  - The Python v3 (Boto3) entry is unchanged.
  
  **Why the version key matters**
  
  The numeric key under sdk: is parsed as the actual SDK version (int(version) → sdk_version in
  sdks.py). Leaving the key as 1 while the contents describe v4 would cause example metadata using
  sdk_version: 4 to fail to resolve. The key is set to 4 so v4 registers correctly.
  
  **Testing**
  
  - pytest full suite: 108 passed
  - The v4 entity references (&Python4;, &Python4long;, &guide-python4-api;) are defined in the
  downstream doc-build system, consistent with how v3 and all other SDK entities are handled in
  this repo.
  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
