### PR TITLE
Python v4 updates

### DIFF
--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -286,16 +286,16 @@ Python:
   property: python
   sdk:
     1:
-      long: "&Python1long;"
-      short: "&Python1;"
+      long: "&Python4long;"
+      short: "&Python4;"
       expanded:
-        long: "AWS SDK for Python"
-        short: "SDK for Python"
-      guide: "https://docs.aws.amazon.com/sdk-for-python/v1/guide/index.html"
+        long: "AWS SDK for Python v4"
+        short: "SDK for Python v4"
+      guide: "https://docs.aws.amazon.com/sdk-for-python/v4/guide/index.html"
       api_ref:
-        uid: "pythonv1"
-        name: "&guide-python1-api;"
-        link_template: "https://docs.aws.amazon.com/sdk-for-python/v1/reference/index.html"
+        uid: "pythonv4"
+        name: "&guide-python4-api;"
+        link_template: "https://docs.aws.amazon.com/sdk-for-python/v4/reference/index.html"
     3:
       long: "&Python3long;"
       short: "&Python3;"

--- a/aws_doc_sdk_examples_tools/config/sdks.yaml
+++ b/aws_doc_sdk_examples_tools/config/sdks.yaml
@@ -285,7 +285,7 @@ PowerShell:
 Python:
   property: python
   sdk:
-    1:
+    4:
       long: "&Python4long;"
       short: "&Python4;"
       expanded:


### PR DESCRIPTION
Removes the `api_ref` block from the **Python v4** SDK entry in `aws_doc_sdk_examples_tools/config/sdks.yaml`.
  
The Python v4 API Reference site is not yet available. With `api_ref` present,  the generated "For API details, see &lt;Action&gt; in AWS SDK for Python v4 API  Reference" crosslinks resolve (via goto) to a fallback landing page rather than a real per-operation reference page. Removing the entire `api_ref` block suppresses those crosslinks for all Python v4 examples until the v4 API reference is live.

**Note**: 
- Additional steps are required to push these changes once merged to the the released version of aws-doc-sdk-examples-tools (see [New Releases](https://github.com/awsdocs/aws-doc-sdk-examples-tools#2-deployment))
- PR in draft so Python team can review

**Why this is safe**
  
- A fully-absent api_ref is the supported "no API reference" state. SdkVersion.api_ref  is Optional and SdkApiRef.from_yaml returns None when the block is omitted (a present-but-missing-uid block would error, but a fully-removed block does not).
- There is existing precedent for this state in the same file: the Java v1 entry has no api_ref block and renders without a "For API details" crosslink.
  
**Testing**
  - sdks.parse(..., strict=True) returns Python v4: api_ref=None, `Python v3: api_ref=SdkApiRef(...)`, with 0 metadata errors.
  
  - Built a full Code Library doc build on a Cloud Desktop (AWSDevDocs/aws-doc-examples version set, AWSDocsSdkExamplesPublic consuming this package as the Aws-doc-sdk-examples-tools build-tool dependency). Confirmed in the generated dynamodb_Hello_Python.xml:
  
    - The Python v4 entries render with no "For API details" block (crosslink removed).
    - The Python v3 entires render "For API details, see ListTables in &lt;SDK for Python (Boto3)&gt;", unchanged.
  
**Blast radius**
sdks.yaml is shared config, so this affects the API-reference crosslink for all Python v4 examples repo-wide, which is the intended outcome until the v4 API reference is published.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
